### PR TITLE
Set width of dropdown on open and not on mount

### DIFF
--- a/src/dropdowns/dropdown-list.jsx
+++ b/src/dropdowns/dropdown-list.jsx
@@ -30,7 +30,7 @@ var propTypes = {
   valueComponent: React.PropTypes.component,
   itemComponent:  React.PropTypes.component,
   busy:           React.PropTypes.bool,
-  
+
   delay:          React.PropTypes.number,
 
   messages:       React.PropTypes.shape({
@@ -39,16 +39,16 @@ var propTypes = {
 };
 
 module.exports = React.createClass({
-  
+
   displayName: 'DropdownList',
 
-  mixins: [ 
+  mixins: [
     require('../mixins/PureRenderMixin'),
     require('../mixins/TextSearchMixin'),
     require('../mixins/DataHelpersMixin'),
     require('../mixins/RtlParentContextMixin'),
-    require('../mixins/DataIndexStateMixin')('selectedIndex'), 
-    require('../mixins/DataIndexStateMixin')('focusedIndex')    
+    require('../mixins/DataIndexStateMixin')('selectedIndex'),
+    require('../mixins/DataIndexStateMixin')('focusedIndex')
   ],
 
   propTypes: propTypes,
@@ -60,7 +60,7 @@ module.exports = React.createClass({
 			open:          false,
       selectedIndex: initialIdx,
       focusedIndex:  initialIdx === -1 ? 0 : initialIdx,
-      
+
 		}
 	},
 
@@ -75,16 +75,12 @@ module.exports = React.createClass({
 
   componentWillReceiveProps: ifShouldUpdate(function(props){
     var idx = this._dataIndexOf(props.data, props.value);
-    
+
     this.setSelectedIndex(idx)
     this.setFocusedIndex(idx === -1 ? 0 : idx)
   }),
 
-  componentDidMount: function(){
-    this.setWidth()
-  },
-
-	render: function(){ 
+	render: function(){
 		var keys = _.keys(propTypes)
       , valueItem = this._dataItem( this._data(), this.props.value )
       , optID = this.props.id && this.props.id + '_option' || '';
@@ -94,7 +90,7 @@ module.exports = React.createClass({
 			<div ref="element"
            onKeyDown={this._keyDown}
            onClick={this.toggle}
-           onFocus={this._focus.bind(null, true)} 
+           onFocus={this._focus.bind(null, true)}
            onBlur ={this._focus.bind(null, false)}
            aria-expanded={ this.state.open }
            aria-haspopup={true}
@@ -114,30 +110,30 @@ module.exports = React.createClass({
           </i>
 				</span>
         <div className="rw-input">
-          { this.props.valueComponent 
+          { this.props.valueComponent
               ? this.props.valueComponent({ item: valueItem })
               : this._dataText(valueItem)
           }
         </div>
 
-        <Popup 
+        <Popup
           style={{ width: this.state.width }}
-          getAnchor={ this._getAnchor } 
-          open={this.state.open} 
+          getAnchor={ this._getAnchor }
+          open={this.state.open}
           onRequestClose={this.close}>
-          
+
           <div>
             <List ref="list"
               optID={optID}
               aria-hidden={ !this.state.open }
               style={{ maxHeight: 200, height: 'auto' }}
-              data={this.props.data} 
+              data={this.props.data}
               value={this.props.value}
               initialVisibleItems={this.props.initialBufferSize}
               itemHeight={18}
               selectedIndex={this.state.selectedIndex}
               focusedIndex={this.state.focusedIndex}
-              textField={this.props.textField} 
+              textField={this.props.textField}
               valueField={this.props.valueField}
               listItem={this.props.itemComponent}
               onSelect={this._onSelect}/>
@@ -152,7 +148,7 @@ module.exports = React.createClass({
       , changed = width !== this.state.width;
 
     if ( changed )
-      this.setState({ width: width })   
+      this.setState({ width: width })
   },
 
   _focus: function(focused){
@@ -161,7 +157,7 @@ module.exports = React.createClass({
     clearTimeout(self.timer)
     self.timer = setTimeout(function(){
 
-      if(focused) self.getDOMNode().focus() 
+      if(focused) self.getDOMNode().focus()
       else        self.close()
 
       if( focused !== self.state.focused)
@@ -199,7 +195,7 @@ module.exports = React.createClass({
       else if ( isOpen ) this.setFocusedIndex(this.nextFocusedIndex())
       else               change(this.nextSelectedIndex())
       e.preventDefault()
-    } 
+    }
     else if ( key === 'ArrowUp' ) {
       if ( alt )         this.close()
       else if ( isOpen ) this.setFocusedIndex(this.prevFocusedIndex())
@@ -217,18 +213,18 @@ module.exports = React.createClass({
   },
 
   change: ifValueChanges(function(data){
-    var change = this.props.onChange 
+    var change = this.props.onChange
     if ( change ) {
       change(data)
       this.close()
-    }  
+    }
   }),
 
   _locate: function(word){
     var key = this.state.open ? 'focusedIndex' : 'selectedIndex'
       , idx = this.findIndex(word, this.state[key])
       , setIndex = setter(key).bind(this);
-      
+
     if ( idx !== -1)
       setIndex(idx)
   },
@@ -238,6 +234,7 @@ module.exports = React.createClass({
   },
 
   open: function(){
+    this.setWidth()
     this.setState({ open: true })
   },
 
@@ -246,8 +243,8 @@ module.exports = React.createClass({
   },
 
   toggle: function(e){
-    this.state.open 
-      ? this.close() 
+    this.state.open
+      ? this.close()
       : this.open()
   },
 


### PR DESCRIPTION
There's probably a much better way to do this, but this is a quick fix. If the length of the options varies (greatly), the width of the dropdown doesn't change, as it's only calculated on mount. `open:` probably isn't the best spot to continue recalcing it though :P 
