### PR TITLE
Add a class to popup container so it can be controlled externally

### DIFF
--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -90,7 +90,7 @@ module.exports = React.createClass({
     Content.props.ref = this.props.children.props.ref;
 
 		return (
-      <div style={style} > 
+      <div style={style} className="rw-popup-container">
         <PopupContent ref='content'>
           { Content }
         </PopupContent>
@@ -121,7 +121,7 @@ module.exports = React.createClass({
       , el   = this.refs.content.getDOMNode();
 
     this.ORGINAL_POSITION = el.style.position;
-    
+
     this.dimensions()
     this.props.onOpening()
 
@@ -159,7 +159,7 @@ module.exports = React.createClass({
       , dur === undefined ? this.props.duration : dur
       , function() {
         $.css(el, { position: self.ORGINAL_POSITION });
-        
+
         anim.style.display = 'none'
         self.ORGINAL_POSITION = null
         self.props.onClose()


### PR DESCRIPTION
I wanted to control a few things (style wise) for the dropdown item, and there was no class on the popup _container_. Instead of using some unreliable css selector, adding a class might work better.
