### PR TITLE
Add a propType of any for ComboBox filter

### DIFF
--- a/src/dropdowns/combobox.jsx
+++ b/src/dropdowns/combobox.jsx
@@ -24,6 +24,8 @@ var btn = require('../common/btn.jsx')
       suggest:        React.PropTypes.bool,
       busy:           React.PropTypes.bool,
 
+      filter:         React.PropTypes.any,
+
       duration:       React.PropTypes.number, //popup
 
       messages:       React.PropTypes.shape({


### PR DESCRIPTION
Hi,

Loving the library so far.  I _think_ I've found a small bug in combobox.js

According to the docs I should be able to pass 

> Mixed - false, "startsWith", "endsWith", "contains", function(item)
> into the filter property of ComboBox.

This seems to throw an invalid property error.  I was able to fix it by adding a filter propType of React.PropTypes.any.

I haven't included any tests for this but I'll try to follow up with some if you want to keep the pull open.
