### PR TITLE
Use secure CDN urls to prevent Firefox blocking mixed active content.

### DIFF
--- a/docs/index.htm
+++ b/docs/index.htm
@@ -3,20 +3,20 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"/>
-    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"/>
 
     <link href="vendor/codemirror.css" rel="stylesheet"/>
     <link href="vendor/neo.css" rel="stylesheet"/>
 
     <link href="vendor/styles.css" rel="stylesheet"/>
-    
+
 
     <link href="../dist/css/react-widgets.css" rel="stylesheet"/>
     <!-- <link href="docs.css" rel="stylesheet"/> -->
 <!--     <link href="http://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.css" rel="stylesheet">
  -->
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/github.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/github.min.css"/>
 
     <meta charset="utf-8" />
 


### PR DESCRIPTION
On Firefox 35, I cannot load https://jquense.github.io/react-widgets/docs/ correctly, because the mixed content protection kicks in https://developer.mozilla.org/en-US/docs/Security/MixedContent