### PR TITLE
Highlight the current day/month/year/decade

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -125,14 +125,15 @@ var Calendar = React.createClass({
     var {
         className
       , ...props } = _.omit(this.props, Object.keys(propTypes))
-      , View     = VIEW[this.state.view]
-      , unit     = this.state.view
-      
-      , disabled = this.props.disabled || this.props.readOnly
-      , date     = this.state.currentDate
-      , labelId  = this._id('_view_label')
-      , key      = this.state.view + '_' + dates[this.state.view](date)
-      , id       = this._id('_view');
+      , View       = VIEW[this.state.view]
+      , unit       = this.state.view
+
+      , disabled   = this.props.disabled || this.props.readOnly
+      , date       = this.state.currentDate
+      , todaysDate = new Date()
+      , labelId    = this._id('_view_label')
+      , key        = this.state.view + '_' + dates[this.state.view](date)
+      , id         = this._id('_view');
 
     return (
       <div {...props }
@@ -168,6 +169,7 @@ var Calendar = React.createClass({
             culture={this.props.culture}
             aria-labelledby={labelId}
             selectedDate={this.props.value}
+            today={todaysDate}
             value={this.state.currentDate}
             onChange={this._maybeHandle(this.change)}
             onKeyDown={this._maybeHandle(this._keyDown)}

--- a/src/Century.jsx
+++ b/src/Century.jsx
@@ -57,9 +57,10 @@ module.exports = React.createClass({
     return (
       <tr key={'row_' + i} role='row'>
       { row.map( (date, i) => {
-        var focused  = dates.eq(date,  this.state.focusedDate,  'decade')
-          , selected = dates.eq(date, this.props.value,  'decade')
-          , d        = inRangeDate(date, this.props.min, this.props.max);
+        var focused       = dates.eq(date,  this.state.focusedDate,  'decade')
+          , selected      = dates.eq(date, this.props.value,  'decade')
+          , d             = inRangeDate(date, this.props.min, this.props.max)
+          , currentDecade = dates.eq(date, this.props.today, 'decade');
 
         return !inRange(date, this.props.min, this.props.max)
           ? <td key={i} role='gridcell' className='rw-empty-cell'>&nbsp;</td>
@@ -74,6 +75,7 @@ module.exports = React.createClass({
                   'rw-off-range':       !inCentury(date, this.props.value),
                   'rw-state-focus':     focused,
                   'rw-state-selected':  selected,
+                  'rw-now':             currentDecade
                  })}>
                 { label(date, this.props.culture) }
               </Btn>

--- a/src/Decade.jsx
+++ b/src/Decade.jsx
@@ -58,8 +58,9 @@ module.exports = React.createClass({
     return (
       <tr key={'row_' + i} role='row'>
       { row.map( (date, i) => {
-        var focused  = dates.eq(date, this.state.focusedDate,  'year')
-          , selected = dates.eq(date, this.props.value,  'year');
+        var focused     = dates.eq(date, this.state.focusedDate,  'year')
+          , selected    = dates.eq(date, this.props.value,  'year')
+          , currentYear = dates.eq(date, this.props.today, 'year');
 
         return !dates.inRange(date, this.props.min, this.props.max, 'year')
           ? <td key={i} role='gridcell' className='rw-empty-cell'>&nbsp;</td>
@@ -73,6 +74,7 @@ module.exports = React.createClass({
                   'rw-off-range':      !inDecade(date, this.props.value),
                   'rw-state-focus':    focused,
                   'rw-state-selected': selected,
+                  'rw-now':            currentYear
                 })}>
                 { dates.format(date, dates.formats.YEAR, this.props.culture) }
               </Btn>

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -63,7 +63,8 @@ module.exports = React.createClass({
       <tr key={'week_' + i} role='row'>
       { row.map( (day, idx) => {
         var focused  = dates.eq(day, this.state.focusedDate, 'day')
-          , selected = dates.eq(day, this.props.selectedDate, 'day');
+          , selected = dates.eq(day, this.props.selectedDate, 'day')
+          , today = dates.eq(day, this.props.today, 'day');
 
         return !dates.inRange(day, this.props.min, this.props.max)
             ? <td  key={'day_' + idx} role='gridcell' className='rw-empty-cell' >&nbsp;</td>
@@ -78,6 +79,7 @@ module.exports = React.createClass({
                     'rw-off-range':      dates.month(day) !== dates.month(this.state.focusedDate),
                     'rw-state-focus':    focused,
                     'rw-state-selected': selected,
+                    'rw-now': today
                   })}
                   id={focused ? id : undefined}>
                   {dates.format(day, 'dd', this.props.culture)}

--- a/src/Year.jsx
+++ b/src/Year.jsx
@@ -57,7 +57,8 @@ module.exports = React.createClass({
       <tr key={i} role='row'>
       { row.map( (date, i) => {
         var focused  = dates.eq(date, this.state.focusedDate,  'month')
-          , selected = dates.eq(date, this.props.value,  'month');
+          , selected = dates.eq(date, this.props.value,  'month')
+          , currentMonth = dates.eq(date, this.props.today, 'month');
 
         return dates.inRange(date, this.props.min, this.props.max, 'month')
           ? (<td key={i} role='gridcell'>
@@ -68,7 +69,8 @@ module.exports = React.createClass({
                 disabled={this.props.disabled}
                 className={cx({
                   'rw-state-focus':    focused,
-                  'rw-state-selected': selected
+                  'rw-state-selected': selected,
+                  'rw-now':            currentMonth
                 })}>
                 { dates.format(date, dates.formats.MONTH_NAME_ABRV, this.props.culture) }
               </Btn>

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -74,6 +74,11 @@
     width: 100%;
   }
 }
+
+.rw-now {
+  font-weight: 600;
+}
+
 .rw-state-focus {
   .state-focus();
 }


### PR DESCRIPTION
Our users feel a little bit lost, especially when they're flicking through a few months to have a look at dates and then come back to the current month (and I agree). Without highlighting the current day/month etc, it's very easy to lose context.

![image](https://cloud.githubusercontent.com/assets/2898239/6453316/d614fb90-c190-11e4-96f2-50eac21fc325.png)
![image](https://cloud.githubusercontent.com/assets/2898239/6453320/de6a81b6-c190-11e4-99e7-1cabe55a72a9.png)
![image](https://cloud.githubusercontent.com/assets/2898239/6453324/e7e8c27a-c190-11e4-95dd-65926941cd2c.png)
![image](https://cloud.githubusercontent.com/assets/2898239/6453327/f1cb4876-c190-11e4-8057-b7ae11d2b47e.png)


I don't really feel comfortable with the naming of `todaysDate`, but `currentDate` is already taken (though in the `state`, using the same name for a local could be confusing?).

Let me know your thoughts, thanks mate!