### PR TITLE
Add support for date range values to `Calendar`

### DIFF
--- a/docs/components/pages/Calendar.jsx
+++ b/docs/components/pages/Calendar.jsx
@@ -42,9 +42,9 @@ var Calendar = React.createClass({
 
         <h2>Props</h2>
 
-        <PropHeader type='Date?' handler="onChange" controllable>value</PropHeader>
+        <PropHeader type='Date? | Array<Date>' handler="onChange" controllable>value</PropHeader>
         <p>
-          The current selected date, should be a Date object or null.
+          The current selected date, should be a Date object, null, or an Array of Date objects.
         </p>
         <EditableExample codeText={require('../examples/valuePicker')(widgetName, ['new Date()'])}/>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"/>
+
+    <link href="vendor/codemirror.css" rel="stylesheet"/>
+    <link href="vendor/neo.css" rel="stylesheet"/>
+
+    <link href="vendor/styles.css" rel="stylesheet"/>
+
+
+    <link href="../dist/css/react-widgets.css" rel="stylesheet"/>
+    <!-- <link href="docs.css" rel="stylesheet"/> -->
+<!--     <link href="http://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.css" rel="stylesheet">
+ -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/github.min.css"/>
+
+    <meta charset="utf-8" />
+
+    <title>React Widgets</title>
+</head>
+<body>
+
+</body>
+<script src="vendor/es5-shim.min.js" type="text/javascript"></script>
+<script src="vendor/es5-sham.min.js" type="text/javascript"></script>
+<!--[if lt IE 9]>
+    <script src="html5shiv.min.js"></script>
+<![endif]-->
+<script src="vendor/codemirror.js" type="text/javascript"></script>
+<script src="vendor/javascript.js"></script>
+<script src="http://fb.me/JSXTransformer-0.12.2.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"></script>
+
+<script src="docs.js" type="text/javascript"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+</html>

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -13,6 +13,8 @@ var _ = require('lodash')
 var { ModalTrigger
   , Modal } = require('react-bootstrap')
 
+var Month = require('../src/Month.jsx');
+
 // var g = require('globalize')
 var culture = require('globalize/lib/cultures/globalize.culture.es');
 // g.culture('fi');
@@ -95,85 +97,12 @@ var App = React.createClass({
           .concat(tag.id)
       })
     }
+    var start = new Date(2015,0,1);
+    var end = new Date(2015,0,5);
+    var noop = function(){};
 
     return (
-      <div style={{ fontSize: 14 }}>
-        <div style={{ maxWidth: 600 }}>
-          <ModalTrigger modal={<MyModal />}>
-            <button>Launch demo modal</button>
-          </ModalTrigger>
-        {/*<section className="example">
-          <div style={{ height: 150 }}>
-            sgsdgsdg sdgdg<br/>assdgsdgsdg<br/>asdasdasdasdasd
-          </div>
-          <SelectList
-            textField='name'
-            valueField='id'
-            data={this.state.data}
-            value={this.state.selectValues}
-            disabled={[1 ,6]}
-            busy={false}
-            name="super_name"
-            multiple
-            onChange={change.bind(null, 'selectValues')}/>
-        </section>*/}
-       
-          <section className="example" style={{ marginBottom: 20 }}>
-            <DropdownList dropUp
-              isRtl={false}
-              id='MyDropdownList'
-              data={ this.state.data }
-              textField='name'
-              valueField='id'
-              busy={false}
-              groupBy='surname'
-              value={this.state.dropdownValue}
-              onChange={change.bind(null, 'dropdownValue')}/>
-          </section>
-          <section className="example" style={{ marginBottom: 20 }}>
-            <Calendar
-              value={ this.state.calValue }
-              min={new Date(2014, 9, 15)}
-              culture='es'
-              onChange={change.bind(null, 'calValue')}/>
-          </section>
-          <section className="example" style={{ marginBottom: 20 }}>
-          <ComboBox
-              isRtl={true}
-              data={ this.state.suggestdata }
-              textField='name'
-              valueField='id'
-              filter={'startsWith'}
-              suggest={true}
-              busy={false}
-              disabled={false}
-              value={ this.state.comboboxValue}
-              onChange={change.bind(null, 'comboboxValue')}/>
-          </section>
-          <section className="example" style={{ marginBottom: 20 }}>
-            <Select dropUp
-              data={ this.state.data }
-              textField='name'
-              valueField='id'/>
-          </section>
-          <section className="example" style={{ marginBottom: 20 }}>
-            <DatePicker dropUp
-              isRtl={false}
-              culture='es'
-              id='swweeeeet'
-              format='f'
-              min={new Date(2013,5,1,0,0,0)}/>
-          </section>
-          <section className="example" style={{ marginBottom: 20 }}>
-            <NumberPicker id='AwesomeNumPicker'
-              isRtl={false}
-              format="D"
-              value={this.state.numberValue}
-              onChange={change.bind(null, 'numberValue')}/>
-          </section>
-        </div>
-      </div>
-
+      <Calendar defaultValue={[start,null]}/>
     )
 
 

--- a/src/Century.jsx
+++ b/src/Century.jsx
@@ -59,7 +59,7 @@ module.exports = React.createClass({
       { row.map( (date, i) => {
         var focused       = dates.eq(date,  this.state.focusedDate,  'decade')
           , selected      = dates.includesOrEquals(date, this.props.value, 'decade')
-          , d             = inRangeDate(date, this.props.min, this.props.max)
+          , d             = dates.scopeToRange(date, this.props.min, this.props.max)
           , currentDecade = dates.eq(date, this.props.today, 'decade');
 
         return !inRange(date, this.props.min, this.props.max)
@@ -112,10 +112,6 @@ module.exports = React.createClass({
 function label(date, culture){
   return dates.format(dates.startOf(date, 'decade'),    dates.formats.YEAR, culture)
     + ' - ' + dates.format(dates.endOf(date, 'decade'), dates.formats.YEAR, culture)
-}
-
-function inRangeDate(decade, min, max){
-  return dates.max( dates.min(decade, max), min)
 }
 
 function inRange(decade, min, max){

--- a/src/Century.jsx
+++ b/src/Century.jsx
@@ -58,7 +58,7 @@ module.exports = React.createClass({
       <tr key={'row_' + i} role='row'>
       { row.map( (date, i) => {
         var focused       = dates.eq(date,  this.state.focusedDate,  'decade')
-          , selected      = dates.eq(date, this.props.value,  'decade')
+          , selected      = dates.includesOrEquals(date, this.props.value, 'decade')
           , d             = inRangeDate(date, this.props.min, this.props.max)
           , currentDecade = dates.eq(date, this.props.today, 'decade');
 

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -230,7 +230,7 @@ var DateTimePicker = React.createClass({
     var change = this.props.onChange
 
     if(constrain)
-      date = this.inRangeValue(date)
+      date = dates.scopeToRange(date, this.props.min, this.props.max)
 
     if( change ) {
       if( date == null || this.props.value == null){
@@ -336,14 +336,6 @@ var DateTimePicker = React.createClass({
   close: function(){
     if ( this.props.open )
       this.notify('onToggle', false)
-  },
-
-  inRangeValue: function(value){
-    if( value == null) return value
-
-    return dates.max(
-        dates.min(value, this.props.max)
-      , this.props.min)
   },
 
 });

--- a/src/Decade.jsx
+++ b/src/Decade.jsx
@@ -59,7 +59,7 @@ module.exports = React.createClass({
       <tr key={'row_' + i} role='row'>
       { row.map( (date, i) => {
         var focused     = dates.eq(date, this.state.focusedDate,  'year')
-          , selected    = dates.eq(date, this.props.value,  'year')
+          , selected    = dates.includesOrEquals(date, this.props.value, 'year')
           , currentYear = dates.eq(date, this.props.today, 'year');
 
         return !dates.inRange(date, this.props.min, this.props.max, 'year')

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -24,7 +24,10 @@ module.exports = React.createClass({
   propTypes: {
     culture:          React.PropTypes.string,
     value:            React.PropTypes.instanceOf(Date),
-    selectedDate:     React.PropTypes.instanceOf(Date),
+    selectedDate:     React.PropTypes.oneOfType([
+      React.PropTypes.instanceOf(Date),
+      React.PropTypes.array,
+    ]),
     min:              React.PropTypes.instanceOf(Date),
     max:              React.PropTypes.instanceOf(Date),
 
@@ -63,7 +66,7 @@ module.exports = React.createClass({
       <tr key={'week_' + i} role='row'>
       { row.map( (day, idx) => {
         var focused  = dates.eq(day, this.state.focusedDate, 'day')
-          , selected = dates.eq(day, this.props.selectedDate, 'day')
+          , selected = dates.includesOrEquals(day, this.props.selectedDate, 'day')
           , today = dates.eq(day, this.props.today, 'day');
 
         return !dates.inRange(day, this.props.min, this.props.max)

--- a/src/Year.jsx
+++ b/src/Year.jsx
@@ -57,7 +57,7 @@ module.exports = React.createClass({
       <tr key={i} role='row'>
       { row.map( (date, i) => {
         var focused  = dates.eq(date, this.state.focusedDate,  'month')
-          , selected = dates.includesOrEquals(date, this.props.value, 'moneth')
+          , selected = dates.includesOrEquals(date, this.props.value, 'month')
           , currentMonth = dates.eq(date, this.props.today, 'month');
 
         return dates.inRange(date, this.props.min, this.props.max, 'month')

--- a/src/Year.jsx
+++ b/src/Year.jsx
@@ -57,7 +57,7 @@ module.exports = React.createClass({
       <tr key={i} role='row'>
       { row.map( (date, i) => {
         var focused  = dates.eq(date, this.state.focusedDate,  'month')
-          , selected = dates.eq(date, this.props.value,  'month')
+          , selected = dates.includesOrEquals(date, this.props.value, 'moneth')
           , currentMonth = dates.eq(date, this.props.today, 'month');
 
         return dates.inRange(date, this.props.min, this.props.max, 'month')

--- a/src/mixins/DateFocusMixin.js
+++ b/src/mixins/DateFocusMixin.js
@@ -14,7 +14,7 @@ module.exports = function(viewUnit, smallUnit){
 
     getInitialState: function(){
       return {
-        focusedDate:   constrainValue(this.props.value, this.props.min, this.props.max)
+        focusedDate:   dates.scopeToRange(this.props.value, this.props.min, this.props.max)
       }
     },
 
@@ -67,10 +67,4 @@ module.exports = function(viewUnit, smallUnit){
       }
     }
   }
-}
-
-
-function constrainValue(value, min, max){
-  if( value == null) return value
-  return dates.max(dates.min(value, max), min)
 }

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -129,6 +129,11 @@ var dates = module.exports = _.assign(dateMath, {
     return this.add(this.startOf(new Date(), 'day'), 1, 'day')
   },
 
+  scopeToRange: function(date, min, max) {
+    if (date == null) return date;
+    return dates.max(dates.min(date, max), min)
+  },
+
   includesOrEquals: function(day, valueOrRange, unit) {
     var isRange = valueOrRange instanceof Array;
 

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -129,6 +129,23 @@ var dates = module.exports = _.assign(dateMath, {
     return this.add(this.startOf(new Date(), 'day'), 1, 'day')
   },
 
+  includesOrEquals: function(day, valueOrRange, unit) {
+    var isRange = valueOrRange instanceof Array;
+
+    if (isRange) {
+      var start = valueOrRange[0] || valueOrRange[1]
+        , end = valueOrRange[1] || valueOrRange[0];
+
+      if (!start || !end) {
+        return false;
+      }
+
+      return dates.inRange(day, start, end, unit)
+    }
+
+    return dates.eq(day, valueOrRange, unit);
+  },
+
   formats: {
     DAY_OF_MONTH:    'dd',
     DAY_NAME_SHORT:  null,

--- a/test/month.browser.jsx
+++ b/test/month.browser.jsx
@@ -41,4 +41,26 @@ describe('Month Component', function(){
     expect(picker.move(date, directions.DOWN))
       .to.eql(date)
   })
+
+  it('should select date ranges', function(){
+    var range1  = [new Date(2014, 0, 16), new Date(2014, 0, 20)]
+      , range2  = [null, null]
+      , picker1 = render(<Month value={range1[0]} selectedDate={range1} onChange={()=>{}}/>)
+      , picker2 = render(<Month value={new Date()} selectedDate={range2} onChange={()=>{}}/>)
+
+
+    expect($(picker1.getDOMNode()).find('.rw-state-selected').length)
+      .to.equal(5);
+
+    expect($(picker2.getDOMNode()).find('.rw-state-selected').length)
+      .to.equal(0);
+  })
+
+  it('should select single dates', function(){
+    var day  = new Date(2014, 0, 16)
+      , picker = render(<Month value={day} selectedDate={day} onChange={()=>{}}/>);
+
+    expect($(picker.getDOMNode()).find('.rw-state-selected').length)
+      .to.equal(1);
+  })
 })

--- a/test/util.browser.js
+++ b/test/util.browser.js
@@ -9,7 +9,8 @@ var React   = require('react')
   , filters = require('../src/util/filter')
   , _       = require('../src/util/_')
   , propTypes = require('../src/util/propTypes')
-  , validateList = require('../src/util/validateListInterface');
+  , validateList = require('../src/util/validateListInterface')
+  , dates = require('../src/util/dates');
 
 
 
@@ -149,4 +150,53 @@ describe('when using custom PropTypes', function(){
     expect(
       propTypes.elementType(props, 'type', 'component')).to.be.an(Error)
   })
+})
+
+describe('dates util', function(){
+
+  describe('includesOrEquals', function(){
+    var day = new Date(2015, 0, 1);
+
+    it('should allow ranges', function() {
+      var dayRangeInclusive = [new Date(2014, 11, 31), new Date(2015, 0, 2)]
+        , dayRangeNonInclusive = [new Date(2014, 11, 30), new Date(2014, 11, 31)]
+        , yearRangeInclusive = [new Date(2015, 0, 1), new Date(2015, 11, 31)]
+        , yearRangeNonInclusive = [new Date(2014, 0, 1), new Date(2014, 11, 31)]
+        , decadeRangeInclusive = [new Date(2010, 0, 1), new Date(2019, 0, 1)]
+        , decadeRangeNonInclusive = [new Date(2020, 0, 1), new Date(2029, 0, 1)]
+        , nullStartInclusive = [null, new Date(2015, 0, 1)]
+        , nullStartNoneInclusive = [null, new Date(2014, 11, 31)]
+        , nullEndInclusive = [new Date(2015, 0, 1), null]
+        , nullEndNoneInclusive = [new Date(2014, 11, 31), null]
+
+      expect(dates.includesOrEquals(day, dayRangeInclusive, 'day')).to.equal(true)
+      expect(dates.includesOrEquals(day, dayRangeNonInclusive, 'day')).to.equal(false)
+      expect(dates.includesOrEquals(day, yearRangeInclusive, 'year')).to.equal(true)
+      expect(dates.includesOrEquals(day, yearRangeNonInclusive, 'year')).to.equal(false)
+      expect(dates.includesOrEquals(day, decadeRangeInclusive, 'decade')).to.equal(true)
+      expect(dates.includesOrEquals(day, decadeRangeNonInclusive, 'decade')).to.equal(false)
+      expect(dates.includesOrEquals(day, nullStartInclusive, 'day')).to.equal(true)
+      expect(dates.includesOrEquals(day, nullStartNoneInclusive, 'day')).to.equal(false)
+      expect(dates.includesOrEquals(day, nullEndInclusive, 'day')).to.equal(true)
+      expect(dates.includesOrEquals(day, nullEndNoneInclusive, 'day')).to.equal(false)
+    })
+
+    it('should allow single dates', function() {
+      var dayInclusive = day
+        , dayNonInclusive = new Date(2015, 0, 2)
+        , yearInclusive = new Date(2015, 4, 1)
+        , yearNonInclusive = new Date(2014, 0, 2)
+        , decadeInclusive = new Date(2010, 0, 1)
+        , decadeNonInclusive = new Date(2020, 0, 1)
+
+      expect(dates.includesOrEquals(day, dayInclusive, 'day')).to.equal(true)
+      expect(dates.includesOrEquals(day, dayNonInclusive, 'day')).to.equal(false)
+      expect(dates.includesOrEquals(day, yearInclusive, 'year')).to.equal(true)
+      expect(dates.includesOrEquals(day, yearNonInclusive, 'year')).to.equal(false)
+      expect(dates.includesOrEquals(day, decadeInclusive, 'decade')).to.equal(true)
+      expect(dates.includesOrEquals(day, decadeNonInclusive, 'decade')).to.equal(false)
+    })
+
+  })
+
 })


### PR DESCRIPTION
This PR adds support for date range values to the calendar widget.

Example:

```js
var start = new Date(2015, 0, 1)
   ,  end = new Date(2015, 0, 10);

<Calendar value={[start, end]} />
```

In the above example, `start` and/or `end` can be `null` as well.  If both values are `null`, then nothing is selected, and if a single value is `null` then only a single date is selected.

Let me know if you need anything else from me to get this in.