### PR TITLE
Open multiselect popup on subsequent input focus; fixes #60

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -180,7 +180,8 @@ var Multiselect = React.createClass({
             placeholder={this._placeholder()}
             onKeyDown={this._searchKeyDown}
             onKeyUp={this._searchgKeyUp}
-            onChange={this._typing}/>
+            onChange={this._typing}
+            onFocus={this._inputFocus}/>
         </div>
         <Popup {..._.pick(this.props, Object.keys(Popup.type.propTypes))}
           onRequestClose={this.close}>
@@ -230,10 +231,10 @@ var Multiselect = React.createClass({
       this.state.dataItems.filter( d => d !== value))
   },
 
-  // _click(e){
-  //   this._focus(true)
-  //   !this.props.open && this.open()
-  // },
+  _inputFocus(e){
+    this._focus(true)
+    !this.props.open && this.open()
+  },
 
   _focus(focused, e){
     if (this.props.disabled === true )

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -8,6 +8,7 @@ module.exports = React.createClass({
   propTypes: {
     value:        React.PropTypes.string,
     onChange:     React.PropTypes.func.isRequired,
+    onFocus:      React.PropTypes.func,
 
     disabled:     React.PropTypes.bool,
     readOnly:     React.PropTypes.bool,


### PR DESCRIPTION
![multifocus](https://cloud.githubusercontent.com/assets/2898239/6608550/face4f4c-c89b-11e4-9590-b1af9460f74e.gif)

As suggested, this uses the (removed) click method. Instead of click, i used the `onFocus` event, because I feel it's more warranted.