### PR TITLE
Multiselect now takes a maxLength prop

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -181,7 +181,8 @@ var Multiselect = React.createClass({
             onKeyDown={this._searchKeyDown}
             onKeyUp={this._searchgKeyUp}
             onChange={this._typing}
-            onFocus={this._inputFocus}/>
+            onFocus={this._inputFocus}
+            maxLength={this.props.maxLength}/>
         </div>
         <Popup {..._.pick(this.props, Object.keys(Popup.type.propTypes))}
           onRequestClose={this.close}>

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -7,6 +7,7 @@ module.exports = React.createClass({
 
   propTypes: {
     value:        React.PropTypes.string,
+    maxLength:    React.PropTypes.number,
     onChange:     React.PropTypes.func.isRequired,
     onFocus:      React.PropTypes.func,
 


### PR DESCRIPTION
Another tiny one, heh.

Our server has a maximum length it can take for a value (for eg 255), so if tags are longer it fails. This PR allows you to pass a maxLength attribute through to cap the tag.