### PR TITLE
Fixes issue with input width in Chrome

### DIFF
--- a/lib/MultiselectInput.js
+++ b/lib/MultiselectInput.js
@@ -23,7 +23,7 @@ module.exports = React.createClass({
   render: function () {
     var value = this.props.value,
         placeholder = this.props.placeholder,
-        size = Math.max((value || placeholder).length, 1);
+        size = Math.max((value || placeholder).length, 1) + 1;
 
     return React.createElement("input", babelHelpers._extends({}, this.props, {
       type: "text",


### PR DESCRIPTION
In Chrome, when you are typing in options in the multiselect, sometimes the input isn't wide enough to fit the text. By adding a slight buffer, it fixes the issue.