### PR TITLE
Unicode multiplication x

### DIFF
--- a/lib/MultiselectTagList.js
+++ b/lib/MultiselectTagList.js
@@ -59,7 +59,7 @@ module.exports = React.createClass({
             { tabIndex: "-1", onClick: !(disabled || readonly) && _this._delete.bind(null, item),
               "aria-disabled": disabled,
               disabled: disabled },
-            "×",
+            "\u00d7",
             React.createElement(
               "span",
               { className: "rw-sr" },

--- a/src/MultiselectTagList.jsx
+++ b/src/MultiselectTagList.jsx
@@ -69,7 +69,7 @@ module.exports = React.createClass({
                 <Btn tabIndex='-1' onClick={!(disabled || readonly) && this._delete.bind(null, item)}
                   aria-disabled={disabled}
                   disabled={disabled}>
-                  &times;<span className="rw-sr">{ "Remove " + this._dataText(item) }</span>
+                  { "\u00d7" }<span className="rw-sr">{ "Remove " + this._dataText(item) }</span>
                 </Btn>
               </li>)
           })}


### PR DESCRIPTION
Replace the "×" with "\u00d7" in the Multiselect. I was having trouble on a legacy webpage with mismatched encodings showing the wrong character (it was showing "Ã—" instead of "×").