### PR TITLE
Changed font-related LESS variables prefix from "fa" to "rw" to avoid clash with Font-Awesome

### DIFF
--- a/lib/less/icons.less
+++ b/lib/less/icons.less
@@ -1,17 +1,17 @@
 
 @font-face {
   font-family: 'RwWidgets';
-  src: ~"url('@{fa-font-path}/rw-widgets.eot?v=@{fa-version}')";
-  src: ~"url('@{fa-font-path}/rw-widgets.eot?#iefix&v=@{fa-version}') format('embedded-opentype')",
-    ~"url('@{fa-font-path}/rw-widgets.woff?v=@{fa-version}') format('woff')",
-    ~"url('@{fa-font-path}/rw-widgets.ttf?v=@{fa-version}') format('truetype')",
-    ~"url('@{fa-font-path}/rw-widgets.svg?v=@{fa-version}#fontawesomeregular') format('svg')";
+  src: ~"url('@{rw-font-path}/rw-widgets.eot?v=@{rw-version}')";
+  src: ~"url('@{rw-font-path}/rw-widgets.eot?#iefix&v=@{rw-version}') format('embedded-opentype')",
+    ~"url('@{rw-font-path}/rw-widgets.woff?v=@{rw-version}') format('woff')",
+    ~"url('@{rw-font-path}/rw-widgets.ttf?v=@{rw-version}') format('truetype')",
+    ~"url('@{rw-font-path}/rw-widgets.svg?v=@{rw-version}#fontawesomeregular') format('svg')";
   font-weight: normal;
   font-style: normal;
 }
 
 
-.@{fa-css-prefix} {
+.@{rw-css-prefix} {
   display: inline-block;
   font-family: RwWidgets;
   font-style: normal;
@@ -23,11 +23,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.@{fa-css-prefix}-caret-down:before { content: '\e803'; }
-.@{fa-css-prefix}-caret-up:before { content: '\e800'; }
-.@{fa-css-prefix}-caret-left:before { content: '\e801';  }
-.@{fa-css-prefix}-caret-right:before { content: '\e802'; }
+.@{rw-css-prefix}-caret-down:before { content: '\e803'; }
+.@{rw-css-prefix}-caret-up:before { content: '\e800'; }
+.@{rw-css-prefix}-caret-left:before { content: '\e801';  }
+.@{rw-css-prefix}-caret-right:before { content: '\e802'; }
 
-.@{fa-css-prefix}-clock-o:before { content:'\e805'; }
-.@{fa-css-prefix}-calendar:before { content: '\e804'; }
-.@{fa-css-prefix}-search:before { content: '\e806'; } 
+.@{rw-css-prefix}-clock-o:before { content:'\e805'; }
+.@{rw-css-prefix}-calendar:before { content: '\e804'; }
+.@{rw-css-prefix}-search:before { content: '\e806'; }

--- a/lib/less/variables.less
+++ b/lib/less/variables.less
@@ -1,3 +1,3 @@
-@fa-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
-@fa-css-prefix:       rw-i;
-@fa-version:          "4.1.0";
+@rw-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
+@rw-css-prefix:       rw-i;
+@rw-version:          "4.1.0";

--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -1,17 +1,17 @@
 
 @font-face {
   font-family: 'RwWidgets';
-  src: ~"url('@{fa-font-path}/rw-widgets.eot?v=@{fa-version}')";
-  src: ~"url('@{fa-font-path}/rw-widgets.eot?#iefix&v=@{fa-version}') format('embedded-opentype')",
-    ~"url('@{fa-font-path}/rw-widgets.woff?v=@{fa-version}') format('woff')",
-    ~"url('@{fa-font-path}/rw-widgets.ttf?v=@{fa-version}') format('truetype')",
-    ~"url('@{fa-font-path}/rw-widgets.svg?v=@{fa-version}#fontawesomeregular') format('svg')";
+  src: ~"url('@{rw-font-path}/rw-widgets.eot?v=@{rw-version}')";
+  src: ~"url('@{rw-font-path}/rw-widgets.eot?#iefix&v=@{rw-version}') format('embedded-opentype')",
+    ~"url('@{rw-font-path}/rw-widgets.woff?v=@{rw-version}') format('woff')",
+    ~"url('@{rw-font-path}/rw-widgets.ttf?v=@{rw-version}') format('truetype')",
+    ~"url('@{rw-font-path}/rw-widgets.svg?v=@{rw-version}#fontawesomeregular') format('svg')";
   font-weight: normal;
   font-style: normal;
 }
 
 
-.@{fa-css-prefix} {
+.@{rw-css-prefix} {
   display: inline-block;
   font-family: RwWidgets;
   font-style: normal;
@@ -23,11 +23,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.@{fa-css-prefix}-caret-down:before { content: '\e803'; }
-.@{fa-css-prefix}-caret-up:before { content: '\e800'; }
-.@{fa-css-prefix}-caret-left:before { content: '\e801';  }
-.@{fa-css-prefix}-caret-right:before { content: '\e802'; }
+.@{rw-css-prefix}-caret-down:before { content: '\e803'; }
+.@{rw-css-prefix}-caret-up:before { content: '\e800'; }
+.@{rw-css-prefix}-caret-left:before { content: '\e801';  }
+.@{rw-css-prefix}-caret-right:before { content: '\e802'; }
 
-.@{fa-css-prefix}-clock-o:before { content:'\e805'; }
-.@{fa-css-prefix}-calendar:before { content: '\e804'; }
-.@{fa-css-prefix}-search:before { content: '\e806'; } 
+.@{rw-css-prefix}-clock-o:before { content:'\e805'; }
+.@{rw-css-prefix}-calendar:before { content: '\e804'; }
+.@{rw-css-prefix}-search:before { content: '\e806'; }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,3 +1,3 @@
-@fa-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
-@fa-css-prefix:       rw-i;
-@fa-version:          "4.1.0";
+@rw-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
+@rw-css-prefix:       rw-i;
+@rw-version:          "4.1.0";


### PR DESCRIPTION
If a project imports LESS styles from Font-Awesome and then also imports LESS styles from React-Widgets, there is a clash even though the font files are different. I imagine you started from a piece of code you borrowed from Font-Awesome but never bothered to change the name of the variables, you have a good reason now! :grin: 