### PR TITLE
Leverage parser for passing strings as date value

### DIFF
--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -123,7 +123,8 @@ var DateTimePicker = React.createClass({
     var dateListID = this._id('_cal');
     var dropUp = this.props.dropUp;
     var renderPopup = _.isFirstFocusedRender(this) || this.props.open;
-    var value = dateOrNull(this.props.value, [this.props.valueFormat, this.props.editFormat, this.props.format], this.props.culture);
+    var dt = this.props.value;
+    var value = dateOrNull((typeof dt === 'string') ? this._parse(dt) : dt);
     var owns;
 
     if (dateListID && this.props.calendar) owns = dateListID;
@@ -296,7 +297,8 @@ var DateTimePicker = React.createClass({
 
   _selectDate: function _selectDate(date) {
     var format = getFormat(this.props),
-        dateTime = dates.merge(date, dateOrNull(this.props.value)),
+        dt = this.props.value,
+        dateTime = dates.merge(date, dt),
         dateStr = formatDate(date, format, this.props.culture);
 
     this.close();
@@ -307,7 +309,8 @@ var DateTimePicker = React.createClass({
 
   _selectTime: function _selectTime(datum) {
     var format = getFormat(this.props),
-        dateTime = dates.merge(dateOrNull(this.props.value), datum.date),
+        dt = this.props.value,
+        dateTime = dates.merge(dateOrNull((typeof dt === 'string') ? this._parse(dt) : dt), datum.date),
         dateStr = formatDate(datum.date, format, this.props.culture);
 
     this.close();
@@ -390,9 +393,8 @@ function formatsParser(formats, culture, str) {
   return null;
 }
 
-function dateOrNull(dt, formats, culture) {
-  if (typeof dt === 'string') dt = localizers.date.parse(dt, formats, culture);
-  if (dt && !isNaN(dt.getTime())) return dt;
+function dateOrNull(dt) {
+  if (dt && dt.getTime && !isNaN(dt.getTime())) return dt;
   return null;
 }
 // #75: need to aggressively reclaim focus from the calendar otherwise

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -298,7 +298,7 @@ var DateTimePicker = React.createClass({
   _selectDate: function _selectDate(date) {
     var format = getFormat(this.props),
         dt = this.props.value,
-        dateTime = dates.merge(date, dt),
+        dateTime = dates.merge(date, dateOrNull((typeof dt === 'string') ? this._parse(dt) : dt)),
         dateStr = formatDate(date, format, this.props.culture);
 
     this.close();

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -296,7 +296,7 @@ var DateTimePicker = React.createClass({
 
   _selectDate: function _selectDate(date) {
     var format = getFormat(this.props),
-        dateTime = dates.merge(date, this.props.value),
+        dateTime = dates.merge(date, dateOrNull(this.props.value)),
         dateStr = formatDate(date, format, this.props.culture);
 
     this.close();
@@ -307,7 +307,7 @@ var DateTimePicker = React.createClass({
 
   _selectTime: function _selectTime(datum) {
     var format = getFormat(this.props),
-        dateTime = dates.merge(this.props.value, datum.date),
+        dateTime = dates.merge(dateOrNull(this.props.value), datum.date),
         dateStr = formatDate(datum.date, format, this.props.culture);
 
     this.close();

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -123,7 +123,7 @@ var DateTimePicker = React.createClass({
     var dateListID = this._id('_cal');
     var dropUp = this.props.dropUp;
     var renderPopup = _.isFirstFocusedRender(this) || this.props.open;
-    var value = dateOrNull(this.props.value);
+    var value = dateOrNull(this.props.value, [this.props.valueFormat, this.props.editFormat, this.props.format], this.props.culture);
     var owns;
 
     if (dateListID && this.props.calendar) owns = dateListID;
@@ -390,7 +390,8 @@ function formatsParser(formats, culture, str) {
   return null;
 }
 
-function dateOrNull(dt) {
+function dateOrNull(dt, formats, culture) {
+  if (typeof dt === 'string') dt = localizers.date.parse(dt, formats, culture);
   if (dt && !isNaN(dt.getTime())) return dt;
   return null;
 }


### PR DESCRIPTION
This makes it easier to pass in strings as the date `value` and `defaultValue` instead of limiting these to a date object. This is useful since passing in a string from the model is likely the most common use-case.

A new prop called `valueFormat` is also exposed to specify the format for the `value` and `defaultValue`. Although the `editFormat` and `format` props are also tried for parsing the date string making `defaultValue` optional.