### PR TITLE
fix mobile device that use touch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Pick and choose one, or more of the following Components
 
 __Demos and Documentation [here](http://jquense.github.io/react-widgets/docs/)__
 
-### Migration: 2.0
-
-Migration guide can be found [here](http://jquense.github.io/react-widgets/docs/index.htm#migration)
-
 ### Install
 
 `npm install react-widgets`

--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -16,9 +16,12 @@ import { dataItem, dataText, valueMatcher } from './util/dataHelpers';
 import { widgetEditable, widgetEnabled } from './util/interaction';
 import { instanceId, notify, isFirstFocusedRender } from './util/widgetHelpers';
 
+
 var compatCreate = (props, msgs) => typeof msgs.createNew === 'function'
   ? msgs.createNew(props) : [<strong>{`"${props.searchTerm}"`}</strong>, ' ' + msgs.createNew]
 
+React.initializeTouchEvents(true);                             
+                             
 let { omit, pick, splat } = _;
 
 var propTypes = {
@@ -204,6 +207,7 @@ var Multiselect = React.createClass({
         onKeyDown={this._keyDown}
         onFocus={this._focus.bind(null, true)}
         onBlur ={this._focus.bind(null, false)}
+        onTouchEnd={this._focus.bind(null, true)}
         tabIndex={'-1'}
         className={cx(className, 'rw-widget', 'rw-multiselect',  {
           'rw-state-focus':    focused,
@@ -267,6 +271,7 @@ var Multiselect = React.createClass({
             onChange={this._typing}
             onFocus={this._inputFocus}
             onClick={this._inputFocus}
+            onTouchEnd={this._inputFocus}
           />
         </div>
         <Popup {...popupProps}


### PR DESCRIPTION
Currently broken in mobile devices (broswers) because the onClick event in SelectInput is not firing. A current workaround would be to loose focus from the component and then re-focus to gain the popup list. 

Tested and broken in
----------------------------
ipad air, ipad 2

I'm sure other mobile devices that have touch events enabled are broken as well 

I'm not sure if this is the correct branch to pull request to.