### PR TITLE
fix mobile device that use touch events

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -19,6 +19,8 @@ import { instanceId, notify, isFirstFocusedRender } from './util/widgetHelpers';
 var compatCreate = (props, msgs) => typeof msgs.createNew === 'function'
   ? msgs.createNew(props) : [<strong>{`"${props.searchTerm}"`}</strong>, ' ' + msgs.createNew]
 
+React.initializeTouchEvents(true);
+                             
 let { omit, pick, splat } = _;
 
 var propTypes = {
@@ -202,6 +204,7 @@ var Multiselect = React.createClass({
         onKeyDown={this._keyDown}
         onFocus={this._focus.bind(null, true)}
         onBlur ={this._focus.bind(null, false)}
+        onTouchEnd={this._focus.bind(null, true)}
         tabIndex={'-1'}
         className={cx(className, 'rw-widget', 'rw-multiselect',  {
           'rw-state-focus':    focused,
@@ -264,6 +267,7 @@ var Multiselect = React.createClass({
             onChange={this._typing}
             onFocus={this._inputFocus}
             onClick={this._inputFocus}
+            onTouchEnd={this._inputFocus}
           />
         </div>
         <Popup {...popupProps}


### PR DESCRIPTION
Currently broken in mobile devices (broswers) because the onClick event
in SelectInput is not firing. A current workaround would be to loose
focus from the component and then re-focus to gain the popup list.

Tested and broken in
----------------------------
ipad air, ipad 2

I'm sure other mobile devices that have touch events enabled are broken
as well