### PR TITLE
NumberPicker updated to respond to onMouseLeave rather than onMouseOut.

### DIFF
--- a/src/NumberPicker.jsx
+++ b/src/NumberPicker.jsx
@@ -115,7 +115,7 @@ let NumberPicker = React.createClass({
             className={cx({ 'rw-state-active': this.state.active === directions.UP})}
             onMouseDown={this._mouseDown.bind(null, directions.UP)}
             onMouseUp={this._mouseUp.bind(null, directions.UP)}
-            onMouseOut={this._mouseUp.bind(null, directions.UP)}
+            onMouseLeave={this._mouseUp.bind(null, directions.UP)}
             onClick={this._focus.bind(null, true)}
             disabled={val === this.props.max || this.props.disabled}
             aria-disabled={val === this.props.max || this.props.disabled}>
@@ -129,7 +129,7 @@ let NumberPicker = React.createClass({
             className={cx({ 'rw-state-active': this.state.active === directions.DOWN})}
             onMouseDown={this._mouseDown.bind(null, directions.DOWN)}
             onMouseUp={this._mouseUp.bind(null, directions.DOWN)}
-            onMouseOut={this._mouseUp.bind(null, directions.DOWN)}
+            onMouseLeave={this._mouseUp.bind(null, directions.DOWN)}
             onClick={this._focus.bind(null, true)}
             disabled={val === this.props.min || this.props.disabled}
             aria-disabled={val === this.props.min || this.props.disabled}>


### PR DESCRIPTION
Very simple change/fix. Basically, the NumberPicker's up/down caret buttons run `this._mouseUp` in response to React's `onMouseOut`, but we should be using `onMouseLeave` instead. `onMouseOut` is triggered whenever the mouse exits the bounds of any child element inside the targeted element, so when the mouse goes from the up or down caret to the button background, numeric scrolling stops. The only change I made to the source files was replacing the two instances of `onMouseOut` with `onMouseLeave`. I built and tested; with this change, numeric scrolling only stops once the button is exited, as desired.

Note: All I did was make the two minor changes, then `npm install`, and `npm run build`. I'm not sure why this effected changes in so many files but I'm hoping that's what was supposed to happen.