### PR TITLE
support minLength=0 in Multiselect

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -483,7 +483,7 @@ var Multiselect = React.createClass({
 
     this._lengthWithoutValues = items.length;
 
-    if (searchTerm)
+    if (searchTerm || this.props.minLength === 0)
       items = this.filter(items, searchTerm)
 
     return items

--- a/src/mixins/DataFilterMixin.js
+++ b/src/mixins/DataFilterMixin.js
@@ -47,7 +47,7 @@ module.exports = {
             ? getFilter(filters[this.props.filter], searchTerm, this)
             : this.props.filter;
 
-      if ( !matches || !searchTerm || !searchTerm.trim() || searchTerm.length < (this.props.minLength || 1))
+      if ((this.props.minLength !== 0) && ( !matches || !searchTerm || !searchTerm.trim() || searchTerm.length < (this.props.minLength || 1)))
         return items
 
       return items.filter(


### PR DESCRIPTION
This is a pretty small patch to enable minLength=0 in the Multiselect components.

I have a use case where I'd like filtering of the selectable items to take place immediately, based on state changes elsewhere in the app. The custom filter lets me do this, but it won't trigger until at least one character is typed in, even if minLength is 0.

there's probably a better place to put the check than the places I put it, so I won't take it personally if this PR gets the axe, just wanted to post the fix I'm using locally for the sake of example :)

great components in this library all around.