### PR TITLE
Add default browserify transform to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chance": "^0.7.6",
     "cpy": "^3.4.0",
     "css-loader": "^0.15.6",
+    "envify": "^3.0.0",
     "eslint": "^0.24.1",
     "eslint-plugin-mocha": "^0.5.1",
     "eslint-plugin-react": "^2.7.1",
@@ -126,5 +127,10 @@
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1",
     "yargs": "^3.19.0"
+  },
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
   }
 }


### PR DESCRIPTION
This will help preventing additional transformation over resulting files, produced by browserify.
Reactjs works in same way, see https://github.com/facebook/react/blob/master/packages/react/package.json#L29
One difference, that i added envify to devDependencies section