### PR TITLE
remove isRequired from NumberInput parse prop to prevent NumberPicker propType warning

### DIFF
--- a/src/NumberInput.jsx
+++ b/src/NumberInput.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 
     format:       CustomPropTypes.numberFormat,
 
-    parse:        React.PropTypes.func.isRequired,
+    parse:        React.PropTypes.func,
     culture:      React.PropTypes.string,
 
     min:          React.PropTypes.number,


### PR DESCRIPTION
NumberPicker takes an optional parse function but since it is required in NumberInput, you receieve a warning if you do not provide a prop. parse was removed from getDefaultProps in 3.1.5 , this removes the isRequired for parse from the PropTypes declaration in NumberInput to avoid this warning

closes #293 