### PR TITLE
Expose currentDate to props. Fixes #261 and #294.

### DIFF
--- a/docs/components/pages/Calendar.api.md
+++ b/docs/components/pages/Calendar.api.md
@@ -18,10 +18,17 @@ Callback fired when the Calendar navigates between views, or forward and backwar
 
 The minimum date that the Calendar can navigate from.
 
-
 ### max?{ type: 'Date' }
 
 The maximum date that the Calendar can navigate to.
+
+### currentDate?{ type: 'Date', default: 'Date()', handler: 'onCurrentDateChange', controllable: true }
+
+Default current date at which the calendar opens. If none is provided, opens at today's date or the `value` date (if any).
+
+### onCurrentDateChange?{ type: 'Function( Date? date )' }
+
+Change event Handler that is called when the currentDate is changed. The handler is called with the currentDate object
 
 ### footer?{ type: 'Boolean', default: 'false' }
 
@@ -124,6 +131,7 @@ title and screen reader text for the left arrow button
 ### messages.moveForward?{ type: 'String', default: '"navigate forward"' }
 
 title and screen reader text for the right arrow button
+
 
 ## Keyboard Navigation
 

--- a/docs/components/pages/DateTimePicker.api.md
+++ b/docs/components/pages/DateTimePicker.api.md
@@ -62,6 +62,14 @@ the `onChange` handler.
 
 <EditableExample codeText={require('../examples/prop')(widgetName, 'max', 'new Date()')}/>
 
+### currentDate?{ type: 'Date', default: 'Date()', handler: 'onCurrentDateChange', controllable: true }
+
+Default current date at which the calendar opens. If none is provided, opens at today's date or the `value` date (if any).
+
+### onCurrentDateChange?{ type: 'Function( Date? date )' }
+
+Change event Handler that is called when the currentDate is changed. The handler is called with the currentDate object
+
 ### format?{ localizable: true }
 
 A string format used to display the date value. For more information about formats
@@ -150,6 +158,7 @@ title and screen reader text for the left arrow button.
 ### messages.timeButton?{ type: 'String', default: '"Select Time"' }
 
 title and screen reader text for the right arrow button.
+
 
 ## Keyboard Navigation
 

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -34,6 +34,8 @@ let propTypes = {
     onChange:       React.PropTypes.func,
     open:           React.PropTypes.oneOf([false, popups.TIME, popups.CALENDAR]),
     onToggle:       React.PropTypes.func,
+    currentDate:    React.PropTypes.instanceOf(Date),
+    onCurrentDateChange: React.PropTypes.func,
     //------------------------------------
 
     onSelect:       React.PropTypes.func,
@@ -263,6 +265,7 @@ var DateTimePicker = React.createClass({
                 step={step}
                 min={min}
                 max={max}
+                currentDate={this.props.currentDate}
                 culture={culture}
                 onMove={this._scrollTo}
                 preserveDate={!!calendar}
@@ -292,6 +295,8 @@ var DateTimePicker = React.createClass({
               // #75: need to aggressively reclaim focus from the calendar otherwise
               // disabled header/footer buttons will drop focus completely from the widget
               onNavigate={() => this.focus()}
+              currentDate={this.props.currentDate}
+              onCurrentDateChange={this.props.onCurrentDateChange}
             />
           }
         </Popup>
@@ -369,7 +374,7 @@ var DateTimePicker = React.createClass({
   @widgetEditable
   _selectDate(date){
     var format   = getFormat(this.props)
-      , dateTime = dates.merge(date, this.props.value)
+      , dateTime = dates.merge(date, this.props.value, this.props.currentDate)
       , dateStr  = formatDate(date, format, this.props.culture);
 
     this.close()
@@ -381,7 +386,7 @@ var DateTimePicker = React.createClass({
   @widgetEditable
   _selectTime(datum){
     var format   = getFormat(this.props)
-      , dateTime = dates.merge(this.props.value, datum.date)
+      , dateTime = dates.merge(this.props.value, datum.date, this.props.currentDate)
       , dateStr  = formatDate(datum.date, format, this.props.culture);
 
     this.close()
@@ -453,7 +458,7 @@ var DateTimePicker = React.createClass({
 
 export default  createUncontrolledWidget(
     DateTimePicker
-  , { open: 'onToggle', value: 'onChange' });
+  , { open: 'onToggle', value: 'onChange', currentDate: 'onCurrentDateChange' });
 
 
 

--- a/src/TimeList.jsx
+++ b/src/TimeList.jsx
@@ -15,6 +15,7 @@ export default React.createClass({
     value:          React.PropTypes.instanceOf(Date),
     min:            React.PropTypes.instanceOf(Date),
     max:            React.PropTypes.instanceOf(Date),
+    currentDate:    React.PropTypes.instanceOf(Date),
     step:           React.PropTypes.number,
     itemComponent:  CustomPropTypes.elementType,
     format:         CustomPropTypes.dateFormat,
@@ -120,7 +121,7 @@ export default React.createClass({
   },
 
   _dateValues(props){
-    var value = props.value || dates.today()
+    var value = props.value || props.currentDate || dates.today()
       , useDate = props.preserveDate
       , min = props.min
       , max = props.max
@@ -128,8 +129,8 @@ export default React.createClass({
 
     //compare just the time regradless of whether they fall on the same day
     if(!useDate) {
-      start = dates.startOf(dates.merge(new Date(), min), 'minutes')
-      end   = dates.startOf(dates.merge(new Date(), max), 'minutes')
+      start = dates.startOf(dates.merge(new Date(), min, props.currentDate), 'minutes')
+      end   = dates.startOf(dates.merge(new Date(), max, props.currentDate), 'minutes')
 
       if( dates.lte(end, start) && dates.gt(max, min, 'day'))
         end = dates.tomorrow()
@@ -144,8 +145,8 @@ export default React.createClass({
     end = dates.tomorrow()
     //date parts are equal
     return {
-      min: dates.eq(value, min, 'day') ? dates.merge(start, min) : start,
-      max: dates.eq(value, max, 'day') ? dates.merge(start, max) : end
+      min: dates.eq(value, min, 'day') ? dates.merge(start, min, props.currentDate) : start,
+      max: dates.eq(value, max, 'day') ? dates.merge(start, max, props.currentDate) : end
     }
   },
 

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -64,12 +64,12 @@ var dates = Object.assign(dateMath, {
       : date
   },
 
-  merge(date, time){
+  merge(date, time, defaultDate){
     if( time == null && date == null)
       return null
 
-    if( time == null) time = new Date()
-    if( date == null) date = new Date()
+    if( time == null) time = defaultDate || new Date()
+    if( date == null) date = defaultDate || new Date()
 
     date = dates.startOf(date, 'day')
     date = dates.hours(date,        dates.hours(time))

--- a/test/calendar.browser.jsx
+++ b/test/calendar.browser.jsx
@@ -19,7 +19,7 @@ var React = require('react')
 
 var TestUtils = require('react-addons-test-utils')
 var render = TestUtils.renderIntoDocument
-  , findTag = TestUtils.findRenderedDOMComponentWithTag
+  , findMultiTag = TestUtils.scryRenderedDOMComponentsWithTag
   , findClass = TestUtils.findRenderedDOMComponentWithClass
   , findType = TestUtils.findRenderedComponentWithType
   , trigger = TestUtils.Simulate;
@@ -192,24 +192,23 @@ describe('Calendar', () => {
       findClass(footer, 'rw-btn'))
 
     expect(
-      dates.eq(picker.state.currentDate, new Date(), 'day'))
+      dates.eq(picker.props.currentDate, new Date(), 'day'))
         .to.be.ok()
   })
 
   it('should constrain movement by min and max', () => {
     var date     = new Date(2014, 5, 15)
-      , picker   = render(<BaseCalendar value={date} max={new Date(2014, 5, 25)}  min={new Date(2014, 5, 5)} onChange={()=>{}}/>)
+      , picker   = render(<Calendar value={date} max={new Date(2014, 5, 25)}  min={new Date(2014, 5, 5)} onChange={()=>{}}/>)
       , header   = findType(picker, Header)
       , rightBtn = findClass(header, 'rw-btn-right')
       , leftBtn  = findClass(header, 'rw-btn-left');
 
-    trigger.click(rightBtn)
 
-    expect(picker.state.currentDate).to.eql(date)
+    trigger.click(rightBtn)
+    expect(picker.refs.inner.props.currentDate).to.eql(date);
 
     trigger.click(leftBtn)
-
-    expect(picker.state.currentDate).to.eql(date)
+    expect(picker.refs.inner.props.currentDate).to.eql(date);
 
   })
 
@@ -217,18 +216,17 @@ describe('Calendar', () => {
     require('globalize/lib/cultures/globalize.culture.es')
 
     var date   = new Date(2014, 5, 15)
-      , picker = render(<BaseCalendar value={date} culture='es' onChange={()=>{}}/>)
+      , picker = render(<Calendar value={date} culture='es' onChange={()=>{}}/>)
       , headerBtn = findClass(picker, 'rw-btn-view')
-      , head = findTag(picker, 'thead');
 
     syncAnimate()
 
     expect($(headerBtn).text()).to.equal('junio 2014')
-    expect($(head.children[0].firstChild).text()).to.equal('lu')
+    expect($(findMultiTag(picker, 'thead')[0].children[0].firstChild).text()).to.equal('lu')
 
-    picker = render(<BaseCalendar initialView='year' value={date} culture='es' onChange={()=>{}}/>)
+    picker = render(<Calendar initialView='year' value={date} culture='es' onChange={()=>{}}/>)
 
-    expect($(findTag(picker, 'tbody').children[0].firstChild).text())
+    expect($(findMultiTag(picker, 'tbody')[0].children[0].firstChild).text())
       .to.equal('ene')
   })
 
@@ -257,6 +255,18 @@ describe('Calendar', () => {
     calendar = render(<BaseCalendar {...formats} initialView='century' value={date} onChange={()=>{}} />)
 
     expect(findType(calendar, Century).props.decadeFormat).to.equal('decadeFormat')
+  })
+
+  it('should accept a currentDate', function(){
+    var currentDate = new Date(2000, 1, 15)
+    var calendar = render(<Calendar currentDate={currentDate} onCurrentDateChange={()=>{}}/>)
+
+    expect(() => findType(calendar, Month)).to.not.throwException();
+
+    expect(findType(calendar, Month).props.focused.getFullYear()).to.be(2000);
+    expect(findType(calendar, Month).props.focused.getMonth()).to.be(1);
+    expect(findType(calendar, Month).props.focused.getDate()).to.be(15);
+
   })
 
   describe('Date Helpers', () => {


### PR DESCRIPTION
Hi @jquense - let me know any comment.

I kept `currentDate` in the state to minimize the changes and because I wasn't sure on how to make it work with `uncontrollable` and how to update all the tests (the few tries I made weren't conclusive)