### PR TITLE
Fix autoFocus

### DIFF
--- a/src/NumberPicker.jsx
+++ b/src/NumberPicker.jsx
@@ -91,7 +91,6 @@ let NumberPicker = React.createClass({
         className
       , onKeyPress
       , onKeyUp
-      , autoFocus
       , ...props } = _.omit(this.props, Object.keys(propTypes))
       , val = this.constrainValue(this.props.value)
 
@@ -144,7 +143,7 @@ let NumberPicker = React.createClass({
           tabIndex={props.tabIndex}
           placeholder={this.props.placeholder}
           value={val}
-          autoFocus={autoFocus}
+          autoFocus={this.props.autoFocus}
           editing={this.state.focused}
           format={this.props.format}
           parse={this.props.parse}


### PR DESCRIPTION
As `autoFocus` is listed in `propTypes`, the `_.omit` call on line 95 was removing it from `this.props` and thus causing the variable to always be `null`.

I've tested this by hand in a project I'm using NumberPicker in. I've spent some time trying to write a test, but given that React implements `autoFocus` itself instead of passing it to the underlying HTML element, I couldn't figure out how to do this.