### PR TITLE
disableKeyboard feature added

### DIFF
--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -318,11 +318,14 @@ var DateTimePicker = React.createClass({
 
   @widgetEditable
   _keyDown(e){
-    let { open, calendar, time } = this.props;
+    let { open, calendar, time, disableKeyboard } = this.props;
 
     notify(this.props.onKeyDown, [e])
-
+    
     if (e.defaultPrevented)
+      return
+
+    if (disableKeyboard)
       return
 
     if (e.key === 'Escape' && open)


### PR DESCRIPTION
Hello, I like your components.
I found that when the calendar is opened is not possible to change the text with keyboard because arrows are used to move the current day.
I think that will be useful to permit the developer to choose if, for the user, the keyboard is used to move betweeb days or to edit date.
Then I add a line of code to return if the property is specified.
Thank you if you implement it.