### PR TITLE
Add support for array data items in Dropdown and ComboBox

### DIFF
--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -34,7 +34,10 @@ let propTypes = {
       groupBy:        CustomPropTypes.accessor,
 
       data:           React.PropTypes.array,
-      valueField:     React.PropTypes.string,
+      valueField:     React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number
+      ]),
       textField:      CustomPropTypes.accessor,
       name:           React.PropTypes.string,
 

--- a/src/DropdownList.jsx
+++ b/src/DropdownList.jsx
@@ -26,7 +26,10 @@ var propTypes = {
   //------------------------------------
 
   data:           React.PropTypes.array,
-  valueField:     React.PropTypes.string,
+  valueField:     React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number
+  ]),
   textField:      CustomPropTypes.accessor,
 
   valueComponent: CustomPropTypes.elementType,

--- a/src/util/_.js
+++ b/src/util/_.js
@@ -87,6 +87,8 @@ var _ =
   }
 
 function has(o, k){
+  if(typeof o === 'string' || typeof o === 'number')
+    return false;
   return o ? Object.prototype.hasOwnProperty.call(o, k) : false
 }
 

--- a/src/util/dataHelpers.js
+++ b/src/util/dataHelpers.js
@@ -7,14 +7,14 @@ function accessor(data, field){
     value = field(data)
   else if (data == null)
     value = data
-  else if (typeof field === 'string' && typeof data === 'object' && field in data)
+  else if ((typeof field === 'string' || typeof field === 'number') && typeof data === 'object' && field in data)
     value = data[field]
 
   return value
 }
 
 export function dataValue(item, valueField){
-  return valueField && item && has(item, valueField)
+  return valueField !== undefined && valueField !== null && item && has(item, valueField)
     ? item[valueField]
     : item
 }
@@ -50,10 +50,10 @@ export function dataItem(data, item, valueField){
   // make an attempt to see if we were passed in dataItem vs just a valueField value
   // either an object with the right prop, or a primitive
   // { valueField: 5 } || "hello" [ "hello" ]
-  if (has(item, valueField) || typeof first === typeof val)
+  if (has(item, valueField) || typeof first === typeof item)
     return item
 
-  idx = dataIndexOf(data, dataValue(item, valueField), valueField)
+  idx = dataIndexOf(data, item, valueField)
 
   if (idx !== -1)
     return data[idx]

--- a/src/util/propTypes.js
+++ b/src/util/propTypes.js
@@ -43,6 +43,7 @@ module.exports = {
 
   accessor:     React.PropTypes.oneOfType([
                     React.PropTypes.string,
+                    React.PropTypes.number,
                     React.PropTypes.func
                   ]),
 

--- a/test/DataHelperMixin.browser.js
+++ b/test/DataHelperMixin.browser.js
@@ -2,13 +2,25 @@
 import * as helpers from'../src/util/dataHelpers';
 
 describe('when using DATA HELPERS', function(){
-  it('should get a Value Out', function(){
-    expect(helpers.dataValue(1)).to.equal(1)
-    expect(helpers.dataValue({ a: 3 })).to.eql({ a: 3 })
+  describe('Getting Data Values', () => {
 
-    expect(helpers.dataValue(1, 'value')).to.equal(1)
-    expect(helpers.dataValue({ value: 1 }, 'value')).to.equal(1)
-    expect(helpers.dataValue({ value: { a: 3 } }, 'value')).to.eql({ a: 3 })
+    it('should get a Value Out', function(){
+      expect(helpers.dataValue(1)).to.equal(1)
+      expect(helpers.dataValue({ a: 3 })).to.eql({ a: 3 })
+      expect(helpers.dataValue([ 3 ])).to.eql([ 3 ])
+
+      expect(helpers.dataValue(1, 'value')).to.equal(1)
+      expect(helpers.dataValue({ value: 1 }, 'value')).to.equal(1)
+      expect(helpers.dataValue({ value: { a: 3 } }, 'value')).to.eql({ a: 3 })
+
+      expect(helpers.dataValue(1, 0)).to.equal(1)
+      expect(helpers.dataValue(1, 1)).to.equal(1)
+      expect(helpers.dataValue([ 1 ], 0)).to.equal(1)
+      expect(helpers.dataValue([ 1, 2 ], 1)).to.equal(2)
+      expect(helpers.dataValue([ { a: 3 } ], 0)).to.eql({ a: 3 })
+      expect(helpers.dataValue([ { a: 3 }, 'foo' ], 1)).to.eql('foo')
+    })
+
   })
 
   describe('Reading Data Text', () => {
@@ -17,21 +29,28 @@ describe('when using DATA HELPERS', function(){
 
       expect(helpers.dataText('hi')).to.be.a('string').and.to.equal('hi')
       expect(helpers.dataText({ a: 3 })).to.be.a('string').and.to.equal('[object Object]')
+      expect(helpers.dataText([ 1 ])).to.be.a('string').and.to.equal('1')
       expect(helpers.dataText(null)).to.be.a('string').and.to.equal('')
       expect(helpers.dataText(4)).to.be.a('string').and.to.equal('4')
     })
 
     it('should use specified field', function(){
+      expect(helpers.dataText(2, 'text')).to.equal('2')
+      expect(helpers.dataText(2, 1)).to.equal('2')
       expect(helpers.dataText('hi', 'text')).to.equal('hi')
       expect(helpers.dataText(Object.create({ text: 'hi' }, {}), 'text')).to.equal('hi')
       expect(helpers.dataText(Object.create(null, { text: { value: 'hi' } }), 'text')).to.equal('hi')
       expect(helpers.dataText({ text: 'hi' }, 'text')).to.equal('hi')
       expect(helpers.dataText({ text: { a: 3 } }, 'text')).to.eql('[object Object]')
+      expect(helpers.dataText([ 'hi' ], 0)).to.equal('hi')
+      expect(helpers.dataText([ { a: 3 } ], 0)).to.eql('[object Object]')
     })
 
     it('should fall back to item when missing field', function(){
       expect(helpers.dataText('hi', 'text')).to.equal('hi')
       expect(helpers.dataText({ missing: 'hi' }, 'text')).to.equal('[object Object]')
+      expect(helpers.dataText([ 'hi' ], 0)).to.equal('hi')
+      expect(helpers.dataText([ { a: 3 } ], 0)).to.eql('[object Object]')
     })
 
     it('should work as a function accessor', function(){
@@ -40,25 +59,71 @@ describe('when using DATA HELPERS', function(){
       expect(helpers.dataText({ text: 'hi' }, textField)).to.equal('hi hi')
       expect(helpers.dataText({ text: 'john' }, textField)).to.equal('john hi')
       expect(helpers.dataText({ text: { a: 3 } }, textField)).to.eql('[object Object] hi')
+
+      textField = item => item[0] + ' hi';
+
+      expect(helpers.dataText([ 'hi' ], textField)).to.equal('hi hi')
+      expect(helpers.dataText([ 'john' ], textField)).to.equal('john hi')
+      expect(helpers.dataText([ { a: 3 } ], textField)).to.eql('[object Object] hi')
     })
+
   })
 
+  describe('Finding Data Values', () => {
 
-  it('should work with indexOf', function(){
-    var val = { value: 3 }
+    it('should work with valueMatcher', function(){
+      expect(helpers.valueMatcher({ id:'j', label:'jimmy' }, { id:'j', label:'jimmy' }, 'id')).to.be(true)
+      expect(helpers.valueMatcher({ id:'j', label:'jimmy' }, { id:'j', label:'jimmy' }, 'label')).to.be(true)
+      expect(helpers.valueMatcher({ id:'j', label:'jimmy' }, { id:'f', label:'foo' }, 'foo')).to.be(false)
 
-    expect(helpers.dataIndexOf([ 2, 3, 1], 1)).to.equal(2)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], [ 'j', 'jimmy' ], 0)).to.be(true)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], [ 'j', 'jimmy' ], 1)).to.be(true)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], [ 'f', 'foo' ], 0)).to.be(false)
 
-    expect(helpers.dataIndexOf([{}, val, {}], val)).to.equal(1)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], 'j', 0)).to.be(true)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], 'jimmy', 1)).to.be(true)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], 'f', 0)).to.be(false)
+      expect(helpers.valueMatcher([ 'j', 'jimmy' ], 'foo', 1)).to.be(false)
 
-    expect(helpers.dataIndexOf([{}, val, {}], { value: 3 })).to.equal(1)
+      expect(helpers.valueMatcher([ 1, 2 ], 1, 0)).to.be(true)
+      expect(helpers.valueMatcher([ 1, 2 ], 2, 1)).to.be(true)
+      expect(helpers.valueMatcher([ 1, 2 ], 2, 0)).to.be(false)
+      expect(helpers.valueMatcher([ 1, 2 ], 1, 1)).to.be(false)
+    })
 
-    expect(helpers.dataIndexOf([{}, val, {}], 3, 'value')).to.equal(1)
+    it('should work with indexOf', function(){
+      var val = { value: 3 }
 
-    expect(
-      helpers.dataIndexOf( [{}, {}, { value: { a: 2 } }], { a: 2 }, 'value')
-    )
-    .to.equal(2)
+      expect(helpers.dataIndexOf([ 2, 3, 1], 1)).to.equal(2)
+      expect(helpers.dataIndexOf([{}, val, {}], val)).to.equal(1)
+      expect(helpers.dataIndexOf([{}, val, {}], { value: 3 })).to.equal(1)
+      expect(helpers.dataIndexOf([{}, val, {}], 3, 'value')).to.equal(1)
+      expect(
+        helpers.dataIndexOf( [{}, {}, { value: { a: 2 } }], { a: 2 }, 'value')
+      )
+      .to.equal(2)
+
+      var arr = [
+        [ 'j', 'jimmy' ],
+        [ 's', 'sally' ],
+        [ 'p', 'pat' ]
+      ];
+
+      // Array item values without a valueField
+      expect(helpers.dataIndexOf(arr, [ 's', 'sally' ])).to.equal(1)
+      expect(helpers.dataIndexOf(arr, [ 'f', 'foo' ])).to.equal(-1)
+
+      // Scalar values with a valueField
+      expect(helpers.dataIndexOf(arr, 'p', 0)).to.equal(2)
+      expect(helpers.dataIndexOf(arr, 'f', 0)).to.equal(-1)
+
+      expect(helpers.dataIndexOf(arr, 'pat', 1)).to.equal(2)
+
+      expect(helpers.dataIndexOf(arr, 'foo', 1)).to.equal(-1)
+
+      expect(helpers.dataIndexOf(arr, [ 'f', 'foo' ], 0)).to.equal(-1)
+    })
+
   })
 
 })

--- a/test/combobox.browser.jsx
+++ b/test/combobox.browser.jsx
@@ -45,6 +45,26 @@ describe('ComboBox', function(){
         expect(c.dom().value).to.be('jimmy'));
   })
 
+  it('should accept array items and numeric textField and valueField', function(){
+    var arr = [
+      [ 0, 'jimmy' ],
+      [ 1, 'sally' ],
+      [ 2, 'pat' ]
+    ];
+
+    $(
+      <ComboBox
+        defaultValue={0}
+        data={arr}
+        textField={1}
+        valueField={0}
+      />
+    ).render()
+      .find('input.rw-input')
+      .tap(c =>
+        expect(c.dom().value).to.be('jimmy'));
+  })
+
   it('should pass NAME down', function(){
     $(
       <ComboBox

--- a/test/dropdown.browser.jsx
+++ b/test/dropdown.browser.jsx
@@ -32,6 +32,19 @@ describe('DROPDOWNS', function(){
       .to.be('jimmy');
   })
 
+  it('should accept array items and numeric textField and valueField', function(){
+    var arr = [
+      [ 0, 'jimmy' ],
+      [ 1, 'sally' ],
+      [ 2, 'pat' ]
+    ];
+    var instance = render(
+          <Dropdown defaultValue={0} data={arr} textField={1} valueField={0} />);
+
+    expect($(findClass(instance, 'rw-input')).text())
+      .to.be('jimmy');
+  })
+
   it('should start closed', function(done){
     var instance = render(<Dropdown defaultValue={0} data={data} textField='label' valueField='id' />);
     var popup = findType(instance, require('../src/Popup.jsx'));


### PR DESCRIPTION
I wanted to use your DropdownList and ComboBox components, but I didn't want to change my internal options structure, which was an array of arrays, where the first element of each item is the value and the second is the label. 

For example:
```javascript
var data = [
      [ 1, 'jimmy' ],
      [ 2, 'sally' ],
      [ 3, 'pat' ]
    ];

var instance = render(
          <Dropdown defaultValue={1} data={data} valueField={0} textField={1} />);
```

Your code _almost_ supported this already, if you make the values of valueField and textField strings, but not quite. This PR includes support for the above, including tests (as far as I got on them).

As it turns out, I ended up removing the components because my designer rebelled at your use of inline styles, but I had already made these changes and I thought others might find them useful. Feel free to merge if you like.

Thanks!