### PR TITLE
Remove redundant lifecycle hook

### DIFF
--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -17,10 +17,6 @@ export default React.createClass({
     readOnly:     CustomPropTypes.readOnly
   },
 
-  componentDidUpdate() {
-    this.props.focused && this.focus()
-  },
-
   render(){
       var value = this.props.value
         , placeholder = this.props.placeholder


### PR DESCRIPTION
Seems like "focused" prop is not used anywhere for MultiselectInput, so this lifecycle hook is probably redundant. If not - feel free to close PR)