### PR TITLE
Add filter property to DateTimePicker

### DIFF
--- a/docs/components/pages/DateTimePicker.api.md
+++ b/docs/components/pages/DateTimePicker.api.md
@@ -131,6 +131,13 @@ Acceptable values are: `false` `"calendar"` `"time"`
 
 <EditableExample codeText={require('../examples/openDateTime')(widgetName)}/>
 
+### filter?{ type: 'RegExp', default: 'undefined' }
+
+Regular expression of what characters to disallow from the input field. Any matched characters will
+not show up in the input field.
+
+<EditableExample codeText={require('../examples/prop')(widgetName, 'filter', '/[^\\d]/g')}/>
+
 ### onToggle?{ type: 'Function(Boolean isOpen)' }
 
 Called when the {widgetName} is about to open or close. `onToggle` should be used

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -15,7 +15,8 @@ export default React.createClass({
 
     value:        React.PropTypes.instanceOf(Date),
     onChange:     React.PropTypes.func.isRequired,
-    culture:      React.PropTypes.string
+    culture:      React.PropTypes.string,
+    filter:       React.PropTypes.instanceOf(RegExp)
   },
 
   getDefaultProps(){
@@ -73,7 +74,11 @@ export default React.createClass({
   },
 
   _change(e){
-    this.setState({ textValue: e.target.value });
+    var nextTextValue = e.target.value
+    if (this.props.filter) {
+      nextTextValue = nextTextValue.replace(this.props.filter, '')
+    }
+    this.setState({ textValue: nextTextValue })
     this._needsFlush = true
   },
 

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -73,6 +73,7 @@ let propTypes = {
                       React.PropTypes.string,
                       React.PropTypes.func
                     ]),
+    filter:         React.PropTypes.instanceOf(RegExp),
 
     'aria-labelledby': React.PropTypes.string,
 
@@ -145,7 +146,7 @@ var DateTimePicker = React.createClass({
       , tabIndex, value,  editFormat, timeFormat
       , culture, duration, step, messages, min, max, busy
       , placeholder, disabled, readOnly, name, dropUp
-      , timeComponent, autoFocus
+      , timeComponent, autoFocus, filter
       , 'aria-labelledby': ariaLabelledby
       , 'aria-describedby': ariaDescribedby } = this.props;
 
@@ -210,6 +211,7 @@ var DateTimePicker = React.createClass({
           editing={focused}
           culture={culture}
           parse={this._parse}
+          filter={filter}
           onChange={this._change}
         />
 


### PR DESCRIPTION
For one of my projects I needed to restrict what characters were allowed in the DateTimePicker input field. This PR allows this functionality through a prop called filter.