### PR TITLE
Fix misleading propTypes error when no localizer configured

### DIFF
--- a/src/util/localizers.js
+++ b/src/util/localizers.js
@@ -141,7 +141,7 @@ function createWrapper(){
   let dummy = {};
 
   if (process.env.NODE_ENV !== 'production' ) {
-    ['formats', 'parse', 'format', 'firstOfWeek', 'precision']
+    ['formats', 'parse', 'format', 'firstOfWeek', 'precision', 'propType']
       .forEach(name => Object.defineProperty(dummy, name, {
         enumerable: true,
         get(){


### PR DESCRIPTION
react-widgets is designed to throw an error if you try to use certain functionality when no localizer is configured. However, it didn't check "propType," so the propType validation function was undefined, resulting in React's propTypes validator throwing confusing messages like

> Warning: Failed propType: Cannot read property 'apply' of undefined Check the render method of `Uncontrolled(NumberPicker)`.

I believe this is the same problem seen in #360.