### PR TITLE
Preserve text selection on tab

### DIFF
--- a/src/NumberInput.jsx
+++ b/src/NumberInput.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import CustomPropTypes from './util/propTypes';
 import { number as numberLocalizer } from './util/localizers';
 
 let getFormat = props => numberLocalizer.getFormat('default', props.format)
+
+// http://stackoverflow.com/a/32598826/25507
+const canUseDOM = !!(
+  (typeof window !== 'undefined' &&
+  window.document && window.document.createElement)
+);
 
 export default React.createClass({
 
@@ -56,6 +63,23 @@ export default React.createClass({
       this.getDefaultState(nextProps))
   },
 
+  componentWillUpdate(nextProps, nextState) {
+    if (canUseDOM) {
+      // Check if we need to restore text selection after pending update.
+      let node = ReactDOM.findDOMNode(this.refs.input);
+      this._selectAll = document.activeElement === node
+        && this.state.stringValue !== nextState.stringValue
+        && node.selectionStart === 0
+        && node.selectionEnd === this.refs.input.value.length;
+    }
+  },
+
+  componentDidUpdate() {
+    if (this._selectAll) {
+      ReactDOM.findDOMNode(this.refs.input).select();
+    }
+  },
+
   render(){
     var value = this.state.stringValue;
 
@@ -71,6 +95,7 @@ export default React.createClass({
         readOnly={this.props.readOnly}
         placeholder={this.props.placeholder}
         value={value}
+        ref='input'
       />
     )
   },


### PR DESCRIPTION
Standard web browser behavior is to select all text within a text input element when tabbing to that element.  NumberPicker behaves this way by default; _however_, if a format is set, so the string value that's displayed while the input has the focus is different than the formatted value that's displayed normally, then switching from the formatted value to the display value loses the text selection.

The only idea I had for a solution was to check if all text is selected before update and, if that's the case, restore the selection after update.

Fixes #375.
