### PR TITLE
Expose select method

### DIFF
--- a/src/NumberPicker.jsx
+++ b/src/NumberPicker.jsx
@@ -227,6 +227,10 @@ let NumberPicker = React.createClass({
     compat.findDOMNode(this.refs.input).focus()
   },
 
+  select() {
+    compat.findDOMNode(this.refs.input).select()
+  },
+
   increment() {
     return this.step(this.props.step)
   },
@@ -269,7 +273,7 @@ let NumberPicker = React.createClass({
 
 
 export default createUncontrolledWidget(
-    NumberPicker, { value: 'onChange' }, ['focus']);
+    NumberPicker, { value: 'onChange' }, ['focus', 'select']);
 
 
 


### PR DESCRIPTION
Exposing a select() method goes well with the existing focus() method and a standard <input> control's behavior.  See https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select.

It's possible for client code to work around the lack of a select()
method by doing

    ReactDOM.findDOMNode(this.refs.picker.refs.inner.refs.input).select();

but that's ugly and brittle.