### PR TITLE
Remove Duplicated Class from Combobox's input

### DIFF
--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -223,7 +223,6 @@ var ComboBox = React.createClass({
           placeholder={placeholder}
           disabled={disabled}
           readOnly={readOnly}
-          className='rw-input'
           value={dataText(valueItem, textField) }
           onChange={this._inputTyping}
           onKeyDown={this._inputKeyDown}


### PR DESCRIPTION
`Combobox` passes `rw-input` to the `ComboboxInput` input as a className.
`ComboboxInput` appends `rw-input` (`" rw-input"`) to that className prop. 
Causing a result of `<input class="rw-input rw-input" ... />`.

Future Topic:
- import cx in ComboboxInput to remove string concatenation 