### PR TITLE
Added rw-img-path variable

### DIFF
--- a/lib/less/core.less
+++ b/lib/less/core.less
@@ -97,7 +97,7 @@
 }
 
 .rw-i.rw-loading {
-  background: url("../img/loading.gif") no-repeat center;
+  background: url("@{rw-img-path}/loading.gif") no-repeat center;
   width: 16px;
   height: 100%;
 
@@ -113,7 +113,7 @@
 
   &:after{
     content: '';
-    background: url("../img/loader-big.gif") no-repeat center;
+    background: url("@{rw-img-path}/loader-big.gif") no-repeat center;
     position:   absolute;
     background-color: #fff;
     opacity: 0.7;

--- a/lib/less/variables.less
+++ b/lib/less/variables.less
@@ -1,3 +1,4 @@
 @rw-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
+@rw-img-path:         "../img";
 @rw-css-prefix:       rw-i;
 @rw-version:          "4.1.0";

--- a/lib/scss/core.scss
+++ b/lib/scss/core.scss
@@ -97,7 +97,7 @@
 }
 
 .rw-i.rw-loading {
-  background: url("../img/loading.gif") no-repeat center;
+  background: url("#{$rw-img-path}/loading.gif") no-repeat center;
   width: 16px;
   height: 100%;
 
@@ -113,7 +113,7 @@
 
   &:after{
     content: '';
-    background: url("../img/loader-big.gif") no-repeat center;
+    background: url("#{$rw-img-path}/loader-big.gif") no-repeat center;
     position:   absolute;
     background-color: #fff;
     opacity: 0.7;

--- a/lib/scss/variables.scss
+++ b/lib/scss/variables.scss
@@ -1,3 +1,4 @@
 $rw-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
+$rw-img-path:         "../img";
 $rw-css-prefix:       rw-i;
 $rw-version:          "4.1.0";

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -97,7 +97,7 @@
 }
 
 .rw-i.rw-loading {
-  background: url("../img/loading.gif") no-repeat center;
+  background: url("@{rw-img-path}/loading.gif") no-repeat center;
   width: 16px;
   height: 100%;
 
@@ -113,7 +113,7 @@
 
   &:after{
     content: '';
-    background: url("../img/loader-big.gif") no-repeat center;
+    background: url("@{rw-img-path}/loader-big.gif") no-repeat center;
     position:   absolute;
     background-color: #fff;
     opacity: 0.7;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,3 +1,4 @@
 @rw-font-path:        "../fonts"; // for referencing Bootstrap CDN font files directly
+@rw-img-path:         "../img";
 @rw-css-prefix:       rw-i;
 @rw-version:          "4.1.0";


### PR DESCRIPTION
Similar to the existing `rw-font-path` variable, it would help to be able to adjust the paths to the loading images, especially when the default relative paths don't resolve correctly (for example, when loaded via `sass-loader` in Webpack).