### PR TITLE
Add `!default` suffix to all Sass variables

### DIFF
--- a/build/lessToSass.js
+++ b/build/lessToSass.js
@@ -69,7 +69,10 @@ function convertVariables(line) {
   // Matches any @ that doesn't have 'media ' or 'import ' after it.
   var atRegex = /@(?!(media|import|mixin|font-face|keyframes)(\s|\())/g;
 
-  return line.replace(atRegex, '$');
+  // Matches any Sass variable line
+  var variableRegex = /^(\$[\w\d-_]+:\s*(.(?!\!default))+);(.*)$/gm;
+
+  return line.replace(atRegex, '$$').replace(variableRegex, '$1 !default;$3');
 }
 
 function convertFileExtensions(line) {


### PR DESCRIPTION
This change to `lessToSass.js` adds ` !default` after the end of all variables in Sass files.

One thing that I really like about Sass is [variable defaults](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_), so that variables can be defined once at the beginning before importing dependencies instead of having to override variables after the fact. LESS instead has "lazy loading" of variables which makes it [technically unneccessary](https://github.com/less/less.js/issues/1706) to have defaults, but also [causes a lot of confusion about the way LESS vs Sass handle their variables](https://getcrunch.co/2015/10/08/less-the-worlds-most-misunderstood-css-pre-processor/). LESS variables are a lot like Javascript hoisting, which tends to rub me the wrong way. Call me old fashioned, but I just prefer a nice simple top-down variable definition.

For example instead of needing to do this (via [`sass-loader`](https://github.com/jtangelder/sass-loader) in Webpack, hence the use of `~`):
```scss
@import '~react-widgets/lib/scss/variables';
@import '~react-widgets/lib/scss/bootstrap-theme';

@import 'react-widgets-config'; // Custom variable overrides

@import '~react-widgets/lib/scss/mixins';
@import '~react-widgets/lib/scss/normalize';
@import '~react-widgets/lib/scss/icons';

@import '~react-widgets/lib/scss/core';
@import '~react-widgets/lib/scss/popup';
@import '~react-widgets/lib/scss/datepicker';
@import '~react-widgets/lib/scss/selectlist';
@import '~react-widgets/lib/scss/multiselect';
```
It can be replaced with a much more compact import:
```scss
@import 'react-widgets-config';
@import '~react-widgets/lib/scss/react-widgets';
```
Similar to how someone might do this with LESS and its lazy loading (via [`less-loader`](https://github.com/webpack/less-loader)):
```less
@import '~react-widgets/lib/less/react-widgets';
@import 'react-widgets-config';
```
