### PR TITLE
Remove unnecessary tilde escape strings

### DIFF
--- a/src/less/core.less
+++ b/src/less/core.less
@@ -353,7 +353,7 @@ ul.rw-list {
 .rw-combobox input.rw-input,
 .rw-datetimepicker input.rw-input,
 .rw-numberpicker input.rw-input {
-  .box-shadow(~"inset 0 1px 1px rgba(0,0,0,.075)");
+  .box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
 }
 
 

--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -1,11 +1,11 @@
 
 @font-face {
   font-family: 'RwWidgets';
-  src: ~"url('@{rw-font-path}/rw-widgets.eot?v=@{rw-version}')";
-  src: ~"url('@{rw-font-path}/rw-widgets.eot?#iefix&v=@{rw-version}') format('embedded-opentype')",
-    ~"url('@{rw-font-path}/rw-widgets.woff?v=@{rw-version}') format('woff')",
-    ~"url('@{rw-font-path}/rw-widgets.ttf?v=@{rw-version}') format('truetype')",
-    ~"url('@{rw-font-path}/rw-widgets.svg?v=@{rw-version}#fontawesomeregular') format('svg')";
+  src: url('@{rw-font-path}/rw-widgets.eot?v=@{rw-version}');
+  src: url('@{rw-font-path}/rw-widgets.eot?#iefix&v=@{rw-version}') format('embedded-opentype'),
+    url('@{rw-font-path}/rw-widgets.woff?v=@{rw-version}') format('woff'),
+    url('@{rw-font-path}/rw-widgets.ttf?v=@{rw-version}') format('truetype'),
+    url('@{rw-font-path}/rw-widgets.svg?v=@{rw-version}#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Removed unnecessary tilde escape strings in `icons.less` for the `url`s in the `@font-face` definition, and one in `core.less` for one of the box-shadow insets. The last escape in `core.less` at [L285](https://github.com/vdh/react-widgets/blob/d46b9b0eefa4114437d7da9ee0cf3e88de1a7526/src/less/core.less#L285) still looks to be necessary since the build stalls without the escape, presumably because of the comma in the value.