### PR TITLE
Trim leading blank line from code examples

### DIFF
--- a/docs/components/EditableExample.jsx
+++ b/docs/components/EditableExample.jsx
@@ -18,9 +18,11 @@ var scope = {
 
 module.exports = React.createClass({
   render() {
+    let { codeText, ...props } = this.props;
     return (
       <Playground
-        {...this.props}
+        {...props}
+        codeText={codeText.trim()}
         mode='jsx'
         theme='oceanicnext'
         scope={scope}


### PR DESCRIPTION
Code examples (e.g., [here](http://jquense.github.io/react-widgets/docs/#/numberpicker?_k=v6gusj)) have blank lines at the beginning. This PR removes those.

This is pretty minor, so feel free to close if you're not worried about it.

Thanks.