### PR TITLE
Update icons.scss

### DIFF
--- a/lib/scss/icons.scss
+++ b/lib/scss/icons.scss
@@ -1,11 +1,11 @@
 
 @font-face {
   font-family: 'RwWidgets';
-  src: "url('#{$rw-font-path}/rw-widgets.eot?v=#{$rw-version}')";
-  src: "url('#{$rw-font-path}/rw-widgets.eot?#iefix&v=#{$rw-version}') format('embedded-opentype')",
-    "url('#{$rw-font-path}/rw-widgets.woff?v=#{$rw-version}') format('woff')",
-    "url('#{$rw-font-path}/rw-widgets.ttf?v=#{$rw-version}') format('truetype')",
-    "url('#{$rw-font-path}/rw-widgets.svg?v=#{$rw-version}#fontawesomeregular') format('svg')";
+  src: url('#{$rw-font-path}/rw-widgets.eot?v=#{$rw-version}');
+  src: url('#{$rw-font-path}/rw-widgets.eot?#iefix&v=#{$rw-version}') format('embedded-opentype'),
+    url('#{$rw-font-path}/rw-widgets.woff?v=#{$rw-version}') format('woff'),
+    url('#{$rw-font-path}/rw-widgets.ttf?v=#{$rw-version}') format('truetype'),
+    url('#{$rw-font-path}/rw-widgets.svg?v=#{$rw-version}#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
url() in double quotes does not work. Probably the script less2scss does not transform `src: ~"url('@{rw-font-path}/rw-widgets.eot?v=@{rw-version}')";` properly. Unfortunately I don't know less syntax to suggest a fix.