### PR TITLE
Improve keyboard navigation performance for open dropdown

### DIFF
--- a/src/List.jsx
+++ b/src/List.jsx
@@ -1,10 +1,10 @@
 import React   from 'react';
 import ListOption from './ListOption';
+import ListOptionItem from './ListOptionItem';
 import CustomPropTypes from './util/propTypes';
 import compat from './util/compat';
 import cn from 'classnames';
 import _  from './util/_';
-import { dataText, dataValue } from './util/dataHelpers';
 import { instanceId, notify } from './util/widgetHelpers';
 import { isDisabledItem, isReadOnlyItem }  from './util/interaction';
 
@@ -90,7 +90,7 @@ export default React.createClass({
             , isReadOnly = isReadOnlyItem(item, this.props);
 
           return (
-            <Option
+            <ListOptionItem
               key={'item_' + idx}
               id={currentId}
               dataItem={item}
@@ -98,19 +98,12 @@ export default React.createClass({
               readOnly={isReadOnly}
               focused={focused === item}
               selected={selected === item}
-              onClick={isDisabled || isReadOnly ? undefined : onSelect.bind(null, item)}
-            >
-              { ItemComponent
-                ? <ItemComponent
-                    item={item}
-                    value={dataValue(item, valueField)}
-                    text={dataText(item, textField)}
-                    disabled={isDisabled}
-                    readOnly={isReadOnly}
-                  />
-                : dataText(item, textField)
-              }
-            </Option>
+              onSelect={onSelect}
+              optionComponent={Option}
+              itemComponent={ItemComponent}
+              textField={textField}
+              valueField={valueField}
+            />
           )
         });
 

--- a/src/ListGroupable.jsx
+++ b/src/ListGroupable.jsx
@@ -1,11 +1,11 @@
 import React   from 'react';
 import ListOption from './ListOption';
+import ListOptionItem from './ListOptionItem';
 import CustomPropTypes from './util/propTypes';
 import compat from './util/compat';
 import cn from 'classnames';
 import _  from './util/_';
 import warning from 'warning';
-import { dataText, dataValue } from './util/dataHelpers';
 import { instanceId, notify } from './util/widgetHelpers';
 import { isDisabledItem, isReadOnlyItem }  from './util/interaction';
 
@@ -163,27 +163,20 @@ export default React.createClass({
       this._currentActiveID = currentID;
 
     return (
-      <Option
+      <ListOptionItem
         key={'item_' + group + '_' + idx}
         id={currentID}
         dataItem={item}
-        focused={focused === item}
-        selected={selected === item}
         disabled={isDisabled}
         readOnly={isReadOnly}
-        onClick={isDisabled || isReadOnly ? undefined : onSelect.bind(null, item)}
-      >
-        { ItemComponent
-            ? <ItemComponent
-                item={item}
-                value={dataValue(item, valueField)}
-                text={dataText(item, textField)}
-                disabled={isDisabled}
-                readOnly={isReadOnly}
-              />
-            : dataText(item, textField)
-        }
-      </Option>
+        focused={focused === item}
+        selected={selected === item}
+        onSelect={onSelect}
+        optionComponent={Option}
+        itemComponent={ItemComponent}
+        textField={textField}
+        valueField={valueField}
+      />
     )
   },
 

--- a/src/ListOptionItem.jsx
+++ b/src/ListOptionItem.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import CustomPropTypes from './util/propTypes';
+import _  from './util/_';
+import { dataText, dataValue } from './util/dataHelpers';
+
+let ListOptionItem = React.createClass({
+  propTypes: {
+    dataItem: React.PropTypes.any,
+    focused:  React.PropTypes.bool,
+    selected: React.PropTypes.bool,
+    disabled: React.PropTypes.bool,
+    readOnly: React.PropTypes.bool,
+
+    onSelect: React.PropTypes.func,
+
+    textField:     CustomPropTypes.accessor,
+
+    optionComponent: CustomPropTypes.elementType.isRequired,
+    itemComponent:   CustomPropTypes.elementType
+  },
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.dataItem !== nextProps.dataItem
+        || this.props.focused !== nextProps.focused
+        || this.props.selected !== nextProps.selected
+        || this.props.disabled !== nextProps.disabled
+        || this.props.readOnly !== nextProps.readOnly
+        || this.props.textField !== nextProps.textField
+        || this.props.optionComponent !== nextProps.optionComponent
+        || this.props.itemComponent !== nextProps.itemComponent;
+  },
+
+  handleClick() {
+    let { disabled, readOnly, dataItem, onSelect } = this.props;
+    if (onSelect && !disabled && !readOnly) {
+      onSelect(dataItem);
+    }
+  },
+
+  render() {
+    let {
+        id
+      , dataItem
+      , disabled
+      , focused
+      , selected
+      , readOnly
+      , textField
+      , valueField
+      , itemComponent: ItemComponent
+      , optionComponent: Option } = this.props;
+
+    return (
+      <Option
+        id={id}
+        dataItem={dataItem}
+        disabled={disabled}
+        readOnly={readOnly}
+        focused={focused}
+        selected={selected}
+        onClick={this.handleClick}
+      >
+        { ItemComponent
+          ? <ItemComponent
+              item={dataItem}
+              value={dataValue(dataItem, valueField)}
+              text={dataText(dataItem, textField)}
+              disabled={disabled}
+              readOnly={readOnly}
+            />
+          : dataText(dataItem, textField)
+        }
+      </Option>
+    )
+  }
+});
+
+export default ListOptionItem;
+


### PR DESCRIPTION
Once a DropdownList has a few hundred items or so, using the keyboard to
navigate an open dropdown list gets _extremely_ slow.  Adding
shouldComponentUpdate dramatically improves performance.

Rather than trying to add shouldComponentUpdate to ListOption (which
would require that ListOption know how its callers are using it and what
its children are), this PR refactors some duplicate code out of List and
ListGroupable into a new ListOptionItem component and adds update
checking there.
