### PR TITLE
FIXED #431 - ComboBox is not correctly handling the id property

### DIFF
--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -250,7 +250,7 @@ var ComboBox = _react2.default.createClass((_obj = {
 
     return _react2.default.createElement(_ComboboxInput2.default, {
       ref: 'input',
-      id: (0, _widgetHelpers.instanceId)(this),
+      id: (0, _widgetHelpers.instanceId)(this, '_input'),
       autoFocus: autoFocus,
       tabIndex: tabIndex,
       suggest: suggest,

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -181,7 +181,7 @@ var ComboBox = React.createClass({
     return (
       <ComboboxInput
         ref='input'
-        id={instanceId(this)}
+        id={instanceId(this, '_input')}
         autoFocus={autoFocus}
         tabIndex={tabIndex}
         suggest={suggest}


### PR DESCRIPTION
This pull request fixes issue #431. The id of the input field in the combobox is suffixed with '_input', just as it was before