### PR TITLE
Fixed active style issue for NumberPicker's down button

### DIFF
--- a/src/NumberPicker.jsx
+++ b/src/NumberPicker.jsx
@@ -125,7 +125,7 @@ let NumberPicker = React.createClass({
             icon="caret-down"
             onClick={this.handleFocus}
             label={this.props.messages.decrement}
-            active={this.state.active === directions.UP}
+            active={this.state.active === directions.DOWN}
             disabled={val === this.props.min || this.props.disabled}
             onMouseUp={() => this.handleMouseUp(directions.DOWN)}
             onMouseDown={() => this.handleMouseDown(directions.DOWN)}


### PR DESCRIPTION
A one-line fix in `NumberPicker` for the down button's active style. The active state is compared against `UP` instead of `DOWN`. It looks to have happened during a recent refactor.