### PR TITLE
add resetIdCount function to _.js util library to fix react server rendering checksum errors

### DIFF
--- a/lib/util/_.js
+++ b/lib/util/_.js
@@ -5,6 +5,9 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var idCount = 0;
 
 var _ = module.exports = {
+  resetIdCount: function resetIdCount() {
+      idCount = 0;
+  },
 
   has: has,
 


### PR DESCRIPTION
When rendering components on the server, react displays an error stating that the checksum was invalid once it reached the client. This was due to the idCount in util/lib/_.js being cached on the server (and being increment on every usage), while on the client it loaded every time the page loads. To fix this issue, I added a function called resetIdCount to the _.js file. A user can import this function and call it before rendering on the server to reset the id count and prevent checksum errors.
