### PR TITLE
fix for manual proptypes call on finalView

### DIFF
--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -163,8 +163,8 @@ var propTypes = {
   view: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
   initialView: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
 
-  finalView: function finalView(props, propName, componentName) {
-    var err = _react2.default.PropTypes.oneOf(VIEW_OPTIONS)(props, propName, componentName);
+  finalView: function finalView(props, propName, componentName, ...rest) {
+    var err = _react2.default.PropTypes.oneOf(VIEW_OPTIONS)(props, propName, componentName, ...rest);
 
     if (err) return err;
     if (VIEW_OPTIONS.indexOf(props[propName]) < VIEW_OPTIONS.indexOf(props.initialView)) return new Error(('The `' + propName + '` prop: `' + props[propName] + '` cannot be \'lower\' than the `initialView`\n        prop. This creates a range that cannot be rendered.').replace(/\n\t/g, ''));


### PR DESCRIPTION
In a future release of React, manually calling PropTypes will not be allowed. Currently it is generating a warning. There is a secret argument that they are using to detect manually calling PropTypes. This pull request implements that fix.

Source: https://facebook.github.io/react/warnings/dont-call-proptypes.html