### PR TITLE
Add support for more semantically correct icons

### DIFF
--- a/dist/react-widgets.js
+++ b/dist/react-widgets.js
@@ -1942,7 +1942,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'aria-label': label,
 	        className: (0, _classnames2.default)(className, 'rw-btn', active && !disabled && 'rw-state-active')
 	      }),
-	      icon && _react2.default.createElement('i', {
+	      icon && _react2.default.createElement('span', {
 	        'aria-hidden': true,
 	        className: (0, _classnames2.default)('rw-i', 'rw-i-' + icon, busy && 'rw-loading')
 	      }),
@@ -8995,7 +8995,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      _react2.default.createElement(
 	        'div',
 	        { className: 'rw-multiselect-wrapper' },
-	        busy && _react2.default.createElement('i', { className: 'rw-i rw-loading' }),
+	        busy && _react2.default.createElement('span', { className: 'rw-i rw-loading' }),
 	        shouldRenderTags && this.renderTags(tagsID, messages),
 	        this.renderInput(inputOwns)
 	      ),

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -60,7 +60,7 @@ var Button = function (_React$Component) {
         'aria-label': label,
         className: (0, _classnames2.default)(className, 'rw-btn', active && !disabled && 'rw-state-active')
       }),
-      icon && _react2.default.createElement('i', {
+      icon && _react2.default.createElement('span', {
         'aria-hidden': true,
         className: (0, _classnames2.default)('rw-i', 'rw-i-' + icon, busy && 'rw-loading')
       }),

--- a/lib/Multiselect.js
+++ b/lib/Multiselect.js
@@ -434,7 +434,7 @@ var Multiselect = _react2.default.createClass((_obj = {
       _react2.default.createElement(
         'div',
         { className: 'rw-multiselect-wrapper' },
-        busy && _react2.default.createElement('i', { className: 'rw-i rw-loading' }),
+        busy && _react2.default.createElement('span', { className: 'rw-i rw-loading' }),
         shouldRenderTags && this.renderTags(tagsID, messages),
         this.renderInput(inputOwns)
       ),

--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -36,7 +36,7 @@ class Button extends React.Component {
         )}
       >
         {icon &&
-          <i
+          <span
             aria-hidden
             className={cn(
               'rw-i',

--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -357,7 +357,7 @@ var Multiselect = React.createClass({
         {this.renderNotificationArea(notifyID, messages)}
 
         <div className='rw-multiselect-wrapper'>
-          {busy && <i className="rw-i rw-loading" />}
+          {busy && <span className="rw-i rw-loading" />}
 
           {shouldRenderTags &&
             this.renderTags(tagsID, messages)


### PR DESCRIPTION
The `Button` and `Multiselect` components utilize the popular `<i>` tag for icons. If a project is required to pass 508 compliance testing before shipping to production, all components inheriting either of the above mentioned components as a base will fail. This PR causes 508 compliance tests to pass by taking a little advice from Font Awesome as referenced here: http://fontawesome.io/examples 

> ...we like the `<i>` tag for brevity, but using a `<span>` is more semantically correct.