### PR TITLE
Change watching attribute from key to keyCode for Japanese IME in Multiselect

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -488,7 +488,7 @@ var Multiselect = React.createClass({
       if (isOpen) this.setState({ focusedItem: list.first(), ...nullTag })
       else          tagList && this.setState({ focusedTag: tagList.first() })
     }
-    else if (isOpen && keyCode === 13) {
+    else if (isOpen && keyCode === 13) { // using keyCode to ignore enter for japanese IME
       e.preventDefault();
       (ctrlKey && this.props.onCreate) || focusedItem === null
         ? this.handleCreate(this.props.searchTerm)

--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -445,7 +445,7 @@ var Multiselect = React.createClass({
 
   @widgetEditable
   handleKeyDown(e) {
-    let { key, altKey, ctrlKey } = e
+    let { key, keyCode, altKey, ctrlKey } = e
       , noSearch = !this.props.searchTerm && !this._deletingText
       , isOpen  = this.props.open;
 
@@ -488,7 +488,7 @@ var Multiselect = React.createClass({
       if (isOpen) this.setState({ focusedItem: list.first(), ...nullTag })
       else          tagList && this.setState({ focusedTag: tagList.first() })
     }
-    else if (isOpen && key === 'Enter') {
+    else if (isOpen && keyCode === 13) {
       e.preventDefault();
       (ctrlKey && this.props.onCreate) || focusedItem === null
         ? this.handleCreate(this.props.searchTerm)

--- a/test/multiselect.browser.jsx
+++ b/test/multiselect.browser.jsx
@@ -358,7 +358,7 @@ describe('Multiselect', function() {
       />
     )
     .render()
-    .trigger('keyDown', { key: 'Enter' })
+    .trigger('keyDown', { keyCode: 13 })
 
     expect(searchSpy.calledOnce).to.be(true)
     expect(searchSpy.calledWith('')).to.be(true)
@@ -464,9 +464,9 @@ describe('Multiselect', function() {
       .trigger('click')
       .tap(assertOnCreateCalled)
       .end()
-    .trigger('keyDown', { key: 'Enter'})
+    .trigger('keyDown', { keyCode: 13 })
       .tap(assertOnCreateCalled)
-    .trigger('keyDown', { key: 'Enter', ctrlKey: true })
+    .trigger('keyDown', { keyCode: 13, ctrlKey: true })
       .tap(assertOnCreateCalled)
   })
 


### PR DESCRIPTION
Japanese user's usually input text with IME (Input Method Editor), and decide word by Enter key. But Multiselect can't distinguish enter for IME and decide tag of Multiselect.

so Multiselect should watch not key attribute but keyCode attribute. because when decide word in IME, keyCode attribute will be "229" but in other cases it will be "13".