### PR TITLE
Allow setting default time

### DIFF
--- a/src/TimeList.jsx
+++ b/src/TimeList.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
 
   getInitialState(){
     var data = this._dates(this.props)
-      , focusedItem = this._closestDate(data, this.props.value);
+      , focusedItem = this._closestDate(data, this.props.value || this.props.currentDate);
 
     return {
       focusedItem: focusedItem || data[0],
@@ -55,7 +55,7 @@ export default React.createClass({
 
   componentWillReceiveProps(nextProps) {
     var data = this._dates(nextProps)
-      , focusedItem = this._closestDate(data, nextProps.value)
+      , focusedItem = this._closestDate(data, nextProps.value || this.props.currentDate)
       , valChanged  = !dates.eq(nextProps.value, this.props.value, 'minutes')
       , minChanged  = !dates.eq(nextProps.min, this.props.min, 'minutes')
       , maxChanged  = !dates.eq(nextProps.max, this.props.max, 'minutes')


### PR DESCRIPTION
It looks like you can currently set a "default start date" for calendar, but not time. The structure is already in place to allow:

```
<DateTimePicker
  currentDate={new Date('1/1/1970 8:00 AM')}
  calendar={false} />
```

to open the time picker at 8 AM:
![](http://g.recordit.co/xOSM0cmO6c.gif)

This just adds a fallback to `currentDate` for `focusedItem` when `value` doesn't exist. 