### PR TITLE
Safer floating point comparison to avoid infinite update loop

### DIFF
--- a/lib/Popup.js
+++ b/lib/Popup.js
@@ -122,21 +122,9 @@ exports.default = _react2.default.createClass({
       return;
     }
 
-    if (opening) {
-      this.open();
-    } else if (closing) {
-      this.close();
-    } else if (open) {
-      // this.height() returns a floating point number with the desired height
-      // for this popup. Because of potential rounding errors in floating point
-      // aritmetic we must allow an error margin when comparing to the current
-      // state, otherwise we can end up in an infinite loop where the height
-      // is never exactly equal to our target value.
+    if (opening) this.open();else if (closing) this.close();else if (open) {
       var height = this.height();
-      var diff = Math.abs(height - this.state.height);
-      if (isNaN(diff) || diff > 0.1) {
-        this.setState({ height: height });
-      }
+      if (height !== this.state.height) this.setState({ height: height });
     }
   },
   render: function render() {

--- a/lib/Popup.js
+++ b/lib/Popup.js
@@ -124,7 +124,10 @@ exports.default = _react2.default.createClass({
 
     if (opening) this.open();else if (closing) this.close();else if (open) {
       var height = this.height();
-      if (height !== this.state.height) this.setState({ height: height });
+      var diff = Math.abs(height - this.state.height);
+      if (isNaN(diff) || diff > 0.1) {
+        this.setState({ height: height });
+      }
     }
   },
   render: function render() {

--- a/lib/Popup.js
+++ b/lib/Popup.js
@@ -122,7 +122,16 @@ exports.default = _react2.default.createClass({
       return;
     }
 
-    if (opening) this.open();else if (closing) this.close();else if (open) {
+    if (opening) {
+      this.open();
+    } else if (closing) {
+      this.close();
+    } else if (open) {
+      // this.height() returns a floating point number with the desired height
+      // for this popup. Because of potential rounding errors in floating point
+      // aritmetic we must allow an error margin when comparing to the current
+      // state, otherwise we can end up in an infinite loop where the height
+      // is never exactly equal to our target value.
       var height = this.height();
       var diff = Math.abs(height - this.state.height);
       if (isNaN(diff) || diff > 0.1) {

--- a/src/Popup.jsx
+++ b/src/Popup.jsx
@@ -97,9 +97,15 @@ export default React.createClass({
     if (opening)      this.open()
     else if (closing) this.close()
     else if (open) {
-      let height = this.height();
-      if (height !== this.state.height)
-        this.setState({ height })
+      // this.height() returns a floating point number with the desired height
+      // for this popup. Because of potential rounding errors in floating point
+      // aritmetic we must allow an error margin when comparing to the current
+      // state, otherwise we can end up in an infinite loop where the height
+      // is never exactly equal to our target value.
+      const height = this.height()
+          , diff = Math.abs(height - this.state.height);
+      if (isNaN(diff) || diff > 0.1)
+        this.setState({ height });
     }
   },
 


### PR DESCRIPTION
Solves #473 by avoiding potential infinite loop for browsers and conditions where the height calculation does not give a stable exact floating point value.