### PR TITLE
Update interaction.js

### DIFF
--- a/src/util/interaction.js
+++ b/src/util/interaction.js
@@ -21,7 +21,7 @@ export function isReadOnlyItem(item, props){
 export function contains(item, values, valueField){
   return Array.isArray(values)
       ? values.some(value => valueMatcher(item, value, valueField))
-      : valueMatcher(item, values, valueField)
+      : false
 }
 
 export function move(dir, item, props, list) {


### PR DESCRIPTION
If `disabled`/`readOnly` is not an array don't assume we want to disable the matching value. In the case of DropdownList any value supplied to `disabled` that is not an array, true, false, or null, throws an invalid prop warning message anyways.
