### PR TITLE
Fixed active style issue for DateTimePicker's buttons

### DIFF
--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -113,7 +113,8 @@ var DateTimePicker = React.createClass({
 
   getInitialState() {
     return {
-      focused: false
+      focused: false,
+      active: false
     }
   },
 
@@ -200,7 +201,11 @@ var DateTimePicker = React.createClass({
             icon="calendar"
             className='rw-btn-calendar'
             label={messages.calendarButton}
+            active={this.state.active === popups.CALENDAR}
             disabled={!!(disabled || readOnly)}
+            onMouseUp={this.handleMouseUp}
+            onMouseDown={() => this.handleMouseDown(popups.CALENDAR)}
+            onMouseLeave={this.handleMouseUp}
             onClick={this._click.bind(null, popups.CALENDAR)}
           />
         }
@@ -209,7 +214,11 @@ var DateTimePicker = React.createClass({
             icon="clock-o"
             className='rw-btn-time'
             label={messages.timeButton}
+            active={this.state.active === popups.TIME}
             disabled={!!(disabled || readOnly)}
+            onMouseUp={this.handleMouseUp}
+            onMouseDown={() => this.handleMouseDown(popups.TIME)}
+            onMouseLeave={this.handleMouseUp}
             onClick={this._click.bind(null, popups.TIME)}
           />
         }
@@ -370,6 +379,16 @@ var DateTimePicker = React.createClass({
 
       }
     }
+  },
+
+  @widgetEditable
+  handleMouseDown(active) {
+    this.setState({ active })
+  },
+
+  @widgetEditable
+  handleMouseUp() {
+    this.setState({ active: false })
   },
 
   @widgetEditable

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -358,9 +358,9 @@ ul.rw-list {
 
 
 .rw-combobox:active,
-.rw-datetimepicker:active,
 .rw-dropdownlist:active,
 .rw-header > .rw-btn:active,
+.rw-datetimepicker .rw-btn.rw-state-active,
 .rw-numberpicker .rw-btn.rw-state-active {
   &,
   &.rw-state-focus {
@@ -410,8 +410,13 @@ ul.rw-list {
   }
 }
 
-.rw-numberpicker {
+.rw-datetimepicker {
+  .rw-btn {
+    border-width: 0;
+  }
+}
 
+.rw-numberpicker {
   .rw-btn {
     display: block;
     height: @input-height / 2;


### PR DESCRIPTION
I noticed when both date and time buttons are available on the `DateTimePicker` component, the active styles will show both buttons pressed when one is pressed.

It reminded me of an earlier issue with `NumberPicker`'s button styles (#442), so I re-implemented the same active state logic that currently exists in `NumberPicker` into `DateTimePicker` so that the active state of the buttons could be separated in a similar way.
