### PR TITLE
Use byteLength instead of length for MultiselectInputt size

### DIFF
--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -17,7 +17,7 @@ class MultiselectInput extends React.Component {
 
   render() {
       let { disabled, readOnly, ...props } = this.props
-      let size = Math.max((props.value || props.placeholder).length, 1) + 1;
+      let size = Math.max((props.value || props.placeholder).byteLength, 1) + 2;
 
       return (
         <input


### PR DESCRIPTION
When multi-byte user inputs this MultiselectInput form, Our character has doubled size to compare with ascii characters. We need to use `byteLength` instead of `length`. 