### PR TITLE
Get size of MultiselectInput by multibyte-length

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "dom-helpers": "^2.2.4",
     "invariant": "^2.1.0",
     "loose-envify": "^1.2.0",
+    "multibyte-length": "^0.1.1",
     "uncontrollable": "^4.0.0",
     "warning": "^2.0.0"
   },

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import _  from './util/_';
 import compat from './util/compat';
 import CustomPropTypes from './util/propTypes';
+import multibyteLength from 'multibyte-length';
 
 class MultiselectInput extends React.Component {
 
@@ -17,7 +18,7 @@ class MultiselectInput extends React.Component {
 
   render() {
       let { disabled, readOnly, ...props } = this.props
-      let size = Math.max((props.value || props.placeholder).length, 1) + 1;
+      let size = Math.max(multibyteLength(props.value || props.placeholder), 1) + 1;
 
       return (
         <input


### PR DESCRIPTION
this PR is another solution for #506 .

currently
<img width="315" alt="2016-12-22 19 30 24" src="https://cloud.githubusercontent.com/assets/7010971/21422969/cc64325a-c87d-11e6-87e6-1088e4484045.png">

this PR
<img width="317" alt="2016-12-22 19 31 13" src="https://cloud.githubusercontent.com/assets/7010971/21422989/f00635be-c87d-11e6-8b3e-8bffab4c9a21.png">

we can't see all of input letters, if we input some multi-byte letters in Multiselect component.
so we need to regard a multi-byte letter as 2 letters, when we count size of input.