### PR TITLE
Add inputSize option to Multiselect

### DIFF
--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -55,6 +55,8 @@ var propTypes = {
                      React.PropTypes.func
                    ]),
 
+  inputSize:       React.PropTypes.func,
+
   busy:            React.PropTypes.bool,
   dropUp:          React.PropTypes.bool,
 
@@ -219,6 +221,7 @@ var Multiselect = React.createClass({
         disabled={disabled === true}
         readOnly={readOnly === true}
         placeholder={this.getPlaceholder()}
+        inputSize={this.props.inputSize}
         onKeyDown={this.handleSearchKeyDown}
         onKeyUp={this.handleSearchKeyUp}
         onChange={this.handleInputChange}

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -22,9 +22,11 @@ class MultiselectInput extends React.Component {
         props.inputSize(props.value || props.placeholder) :
         Math.max((props.value || props.placeholder).length, 1) + 1;
 
+      let elementProps = _.omitOwnProps(this);
+
       return (
         <input
-          {...props}
+          {...elementProps}
           size={size}
           className='rw-input'
           autoComplete='off'

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -19,7 +19,7 @@ class MultiselectInput extends React.Component {
   render() {
       let { disabled, readOnly, ...props } = this.props
       let size = props.inputSize ?
-        props.inputSize((props.value || props.placeholder).length) :
+        props.inputSize(props.value || props.placeholder) :
         Math.max((props.value || props.placeholder).length, 1) + 1;
 
       return (

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -9,6 +9,7 @@ class MultiselectInput extends React.Component {
     value:        React.PropTypes.string,
     placeholder:  React.PropTypes.string,
     maxLength:    React.PropTypes.number,
+    inputSize:    React.PropTypes.func,
     onChange:     React.PropTypes.func.isRequired,
 
     disabled:     CustomPropTypes.disabled,
@@ -17,7 +18,9 @@ class MultiselectInput extends React.Component {
 
   render() {
       let { disabled, readOnly, ...props } = this.props
-      let size = Math.max((props.value || props.placeholder).length, 1) + 1;
+      let size = props.inputSize ?
+        props.inputSize((props.value || props.placeholder).length) :
+        Math.max((props.value || props.placeholder).length, 1) + 1;
 
       return (
         <input


### PR DESCRIPTION
this PR is another solution for #517 , #506 .

I added `inputSize` option to Multiselect for set size of MultiselectInput.
`inputSize` is a function that takes current string and return `size` of `input`.

if this is good to you, I'll add docs for this.