### PR TITLE
Update moment localizer to use strict mode

### DIFF
--- a/dist/react-widgets-moment.js
+++ b/dist/react-widgets-moment.js
@@ -73,7 +73,7 @@
 	  if (!hasLocaleData) throw new TypeError('The Moment localizer depends on the `localeData` api, please provide a moment object v2.2.0 or higher');
 
 	  function getMoment(culture, value, format) {
-	    return culture ? moment(value, format)[localField](culture) : moment(value, format);
+	    return culture ? moment(value, format, true)[localField](culture) : moment(value, format, true);
 	  }
 
 	  function endOfDecade(date) {

--- a/lib/localizers/moment.js
+++ b/lib/localizers/moment.js
@@ -11,7 +11,7 @@ exports.default = function (moment) {
   if (!hasLocaleData) throw new TypeError('The Moment localizer depends on the `localeData` api, please provide a moment object v2.2.0 or higher');
 
   function getMoment(culture, value, format) {
-    return culture ? moment(value, format)[localField](culture) : moment(value, format);
+    return culture ? moment(value, format, true)[localField](culture) : moment(value, format, true);
   }
 
   function endOfDecade(date) {

--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -12,7 +12,7 @@ export default function(moment) {
       'The Moment localizer depends on the `localeData` api, please provide a moment object v2.2.0 or higher')
 
   function getMoment(culture, value, format){
-    return culture ? moment(value, format)[localField](culture) : moment(value, format)
+    return culture ? moment(value, format, true)[localField](culture) : moment(value, format, true)
   }
 
   function endOfDecade(date) {


### PR DESCRIPTION
Fixes #523 

A few things

* I didn't see any guidelines on committing to ./dist and lib, so I went ahead and ran the build and included relevant changes in dist/lib.

* When I ran it I saw some changes that were unrelated (weird), I left those out e.g.:

```diff
-       var dates = _extends(_dateArithmetic2.default, {
+       var dates = _extends({}, _dateArithmetic2.default, {
```

They all seemed to tie to using extends.

* Tests appear to pass

* I've also submitted the same PR to react-widgets-moment-localizer, see:

https://github.com/jquense/react-widgets-moment-localizer/issues/6
https://github.com/jquense/react-widgets-moment-localizer/pull/7