### PR TITLE
Fix webpack sass error by removing root-level child selector

### DIFF
--- a/lib/scss/core.scss
+++ b/lib/scss/core.scss
@@ -136,7 +136,7 @@
   @include state-select();
 }
 
-&.rw-state-disabled {
+.rw-state-disabled {
   @include state-disabled();
   opacity: 1;
 }

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -136,7 +136,7 @@
   .state-select();
 }
 
-&.rw-state-disabled {
+.rw-state-disabled {
   .state-disabled();
   opacity: 1;
 }


### PR DESCRIPTION
Currently, when building with webpack we get the following build error:

```
WebpackError: 
            ModuleBuildError in /node_modules/css-loader/index.js!/node_modules/sass-loader/index.js!/node_modules/react-widgets/lib/scss/react-widgets.scss
            Module build failed: 
&.rw-state-disabled {
^
      Base-level rules cannot contain the parent-selector-referencing character '&'.

Backtrace:
	node_modules/react-widgets/lib/scss/core.scss:139
      in /node_modules/react-widgets/lib/scss/core.scss (line 139, column 1)
```
By removing this character I was able to remove the compilation error.