### PR TITLE
removed duplicate dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "sinon": "^1.17.2",
     "style-loader": "^0.13.1",
     "teaspoon": "^6.4.1",
-    "uncontrollable": "^3.2.3",
     "url-loader": "^0.5.5",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1",


### PR DESCRIPTION
uncontrollable was in both prod and dev dependancies. new versions of npm will prune it, and it just kinda doesn't make sense.