### PR TITLE
Add readOnlyInput option to DateTimePicker

### DIFF
--- a/dist/react-widgets.js
+++ b/dist/react-widgets.js
@@ -3006,12 +3006,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return function decorate(target, key, desc) {
 	    if (desc.initializer) {
-	      (function () {
-	        var init = desc.initializer;
-	        desc.initializer = function () {
-	          return wrap(init());
-	        };
-	      })();
+	      var init = desc.initializer;
+	      desc.initializer = function () {
+	        return wrap(init());
+	      };
 	    } else desc.value = wrap(desc.value);
 	    return desc;
 	  };
@@ -7313,6 +7311,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  autoFocus: _react2.default.PropTypes.bool,
 	  disabled: _propTypes2.default.disabled,
 	  readOnly: _propTypes2.default.readOnly,
+	  readOnlyInput: _propTypes2.default.readOnly,
 
 	  parse: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.string), _react2.default.PropTypes.string, _react2.default.PropTypes.func]),
 
@@ -7381,6 +7380,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        placeholder = _props.placeholder,
 	        disabled = _props.disabled,
 	        readOnly = _props.readOnly,
+	        readOnlyInput = _props.readOnlyInput,
 	        name = _props.name,
 	        tabIndex = _props.tabIndex,
 	        autoFocus = _props.autoFocus,
@@ -7388,6 +7388,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        ariaDescribedby = _props['aria-describedby'];
 	    var focused = this.state.focused;
 
+
+	    readOnly = readOnly || readOnlyInput;
 
 	    return _react2.default.createElement(_DateTimePickerInput2.default, {
 	      id: id,

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -151,6 +151,7 @@ var propTypes = _extends({}, Calendar.propTypes, {
   autoFocus: _react2.default.PropTypes.bool,
   disabled: _propTypes2.default.disabled,
   readOnly: _propTypes2.default.readOnly,
+  readOnlyInput: _propTypes2.default.readOnly,
 
   parse: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.string), _react2.default.PropTypes.string, _react2.default.PropTypes.func]),
 
@@ -219,6 +220,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
         placeholder = _props.placeholder,
         disabled = _props.disabled,
         readOnly = _props.readOnly,
+        readOnlyInput = _props.readOnlyInput,
         name = _props.name,
         tabIndex = _props.tabIndex,
         autoFocus = _props.autoFocus,
@@ -226,6 +228,8 @@ var DateTimePicker = _react2.default.createClass((_obj = {
         ariaDescribedby = _props['aria-describedby'];
     var focused = this.state.focused;
 
+
+    readOnly = readOnly || readOnlyInput;
 
     return _react2.default.createElement(_DateTimePickerInput2.default, {
       id: id,

--- a/lib/util/interaction.js
+++ b/lib/util/interaction.js
@@ -62,12 +62,10 @@ function interactionDecorator(disabledOnly) {
 
   return function decorate(target, key, desc) {
     if (desc.initializer) {
-      (function () {
-        var init = desc.initializer;
-        desc.initializer = function () {
-          return wrap(init());
-        };
-      })();
+      var init = desc.initializer;
+      desc.initializer = function () {
+        return wrap(init());
+      };
     } else desc.value = wrap(desc.value);
     return desc;
   };

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -68,6 +68,7 @@ let propTypes = {
     autoFocus:      React.PropTypes.bool,
     disabled:       CustomPropTypes.disabled,
     readOnly:       CustomPropTypes.readOnly,
+    readOnlyInput:  CustomPropTypes.readOnly,
 
     parse:          React.PropTypes.oneOfType([
                       React.PropTypes.arrayOf(React.PropTypes.string),
@@ -150,6 +151,7 @@ var DateTimePicker = React.createClass({
       , placeholder
       , disabled
       , readOnly
+      , readOnlyInput
       , name
       , tabIndex
       , autoFocus
@@ -157,6 +159,8 @@ var DateTimePicker = React.createClass({
       , 'aria-describedby': ariaDescribedby } = this.props;
 
     let { focused } = this.state;
+
+    readOnly = readOnly || readOnlyInput
 
     return (
       <DateTimePickerInput


### PR DESCRIPTION
I have a common use case where I want to tightly constrain the user's ability to specify a date and/or time. This option makes only the input element read-only. This makes it very easy to force the user to, e.g., stay within the time step limit.

Related: #176