### PR TITLE
Fix aria-owns referencing hidden element

### DIFF
--- a/packages/react-widgets/src/Multiselect.js
+++ b/packages/react-widgets/src/Multiselect.js
@@ -470,9 +470,11 @@ class Multiselect extends React.Component {
       , shouldRenderPopup = isFirstFocusedRender(this) || open
       , allowCreate = this.allowCreate();
 
-    let inputOwns = `${this.listId} ${this.notifyId} `
-      + (shouldRenderTags ? this.tagsId : '')
-      + (allowCreate ? this.createId : '');
+    let inputOwns = cn(this.notifyId, {
+        [this.listId]: shouldRenderPopup
+      , [this.tagsId]: shouldRenderTags
+      , [this.createId]: allowCreate
+    });
 
     let disabled = this.isDisabled() === true
     let readOnly = this.props.readOnly === true


### PR DESCRIPTION
The multiselect input field has the aria-owns attribute referencing the elements that it owns.
On initial render when the popup containing the List has yet to be rendered, so the reference to that ID is invalid.