### PR TITLE
Fixed ambiguous use of mixed operators

### DIFF
--- a/packages/localizer-simple-number/localizer.js
+++ b/packages/localizer-simple-number/localizer.js
@@ -55,7 +55,7 @@ export default function simpleNumber(options = {}) {
     },
 
     decimalChar(format) {
-      return format && deconstruct(format).decimalsSeparator || '.'
+      return (format && deconstruct(format).decimalsSeparator) || '.'
     },
 
     precision(format) {


### PR DESCRIPTION
Added parentheses to a function of the simple-number localizer, which uses mixed operators. This makes the developer's intentions clearer and the code more readable.