### PR TITLE
Fix Multiselect alignment in Firefox (#577).

### DIFF
--- a/packages/react-widgets/src/less/multiselect.less
+++ b/packages/react-widgets/src/less/multiselect.less
@@ -13,6 +13,10 @@
     padding: 0 @input-padding-horizontal;
   }
 
+  .rw-widget-picker > div {
+    vertical-align: top;
+  }
+
   & .rw-select {
     &,
     &:hover,


### PR DESCRIPTION
Add `.rw-multiselect .rw-widget-picker > div { vertical-align: top; }` style to prevent clipping of 2nd row in Firefox