### PR TITLE
Fix DropdownList search above items issue

### DIFF
--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -493,8 +493,7 @@ class DropdownList extends React.Component {
       'search',
       () => {
         var list = this.list,
-          key = this.props.open ? 'focusedItem' : 'selectedItem',
-          item = list.next(this.state[key], word)
+          item = list.next(null, word)
 
         this._currentWord = ''
         if (item) cb(item)

--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -497,7 +497,7 @@ class DropdownList extends React.Component {
           item = list.next(this.state[key], word)
 
         if(item === this.state[key]) {
-          item = list.prev(this.state[key], word)
+          item = list.next(null, word)
         }
 
         this._currentWord = ''

--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -493,7 +493,12 @@ class DropdownList extends React.Component {
       'search',
       () => {
         var list = this.list,
-          item = list.next(null, word)
+          key = this.props.open ? 'focusedItem' : 'selectedItem',
+          item = list.next(this.state[key], word)
+
+        if(item === this.state[key]) {
+          item = list.prev(this.state[key], word)
+        }
 
         this._currentWord = ''
         if (item) cb(item)

--- a/packages/react-widgets/test/DropdownList-test.js
+++ b/packages/react-widgets/test/DropdownList-test.js
@@ -360,4 +360,26 @@ describe('DROPDOWNS', function(){
       done()
     })
   })
+
+  it('should search values on typing when not filtering - back direction', done => {
+    let change = sinon.spy()
+
+    let inst = mount(
+      <ControlledDropdownList
+        open
+        delay={0}
+        filter={false}
+        value={data[2]}
+        data={data}
+        onChange={change}
+        textField='label'
+      />
+    )
+    .simulate('keyPress', { which: 74, key: 'j' })
+
+    setTimeout(() => {
+      expect(inst.state('focusedItem')).to.equal(data[0])
+      done()
+    })
+  })
 })


### PR DESCRIPTION
The solution for this issue:
https://github.com/jquense/react-widgets/issues/596

Because we don't need to rely on the focused or selected item to search through the whole list.