### PR TITLE
Select icon prop

### DIFF
--- a/packages/react-widgets/src/Combobox.js
+++ b/packages/react-widgets/src/Combobox.js
@@ -101,6 +101,7 @@ class Combobox extends React.Component {
     filter: false,
     delay: 500,
     listComponent: List,
+    selectIcon: 'caret-down'
   }
 
   constructor(props, context) {
@@ -341,7 +342,7 @@ class Combobox extends React.Component {
   }
 
   render() {
-    let { className, popupTransition, busy, dropUp, open } = this.props
+    let { className, popupTransition, busy, dropUp, open, selectIcon } = this.props
 
     let { focused } = this.state
 
@@ -371,7 +372,7 @@ class Combobox extends React.Component {
           <Select
             bordered
             busy={busy}
-            icon="caret-down"
+            icon={selectIcon}
             onClick={this.toggle}
             disabled={disabled || readOnly}
             label={messages.openCombobox(this.props)}

--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -128,6 +128,7 @@ class DropdownList extends React.Component {
     searchTerm: '',
     allowCreate: false,
     listComponent: List,
+    selectIcon: 'caret-down'
   }
 
   constructor(...args) {
@@ -396,6 +397,7 @@ class DropdownList extends React.Component {
       placeholder,
       value,
       open,
+      selectIcon,
       filter,
       inputProps,
       valueComponent,
@@ -452,7 +454,7 @@ class DropdownList extends React.Component {
           />
           <Select
             busy={busy}
-            icon="caret-down"
+            icon={selectIcon}
             role="presentational"
             aria-hidden="true"
             disabled={disabled || readOnly}

--- a/packages/react-widgets/src/Multiselect.js
+++ b/packages/react-widgets/src/Multiselect.js
@@ -153,6 +153,8 @@ class Multiselect extends React.Component {
     value: [],
     searchTerm: '',
     listComponent: List,
+    selectIconFocused: 'caret-down',
+    selectIcon: ''
   };
 
   constructor(...args) {
@@ -509,7 +511,9 @@ class Multiselect extends React.Component {
       , dropUp
       , open
       , searchTerm
-      , popupTransition } = this.props;
+      , popupTransition
+      , selectIconFocused
+      , selectIcon } = this.props;
 
     let { focused, focusedItem, dataItems } = this.state;
 
@@ -557,7 +561,7 @@ class Multiselect extends React.Component {
 
           <Select
             busy={busy}
-            icon={focused ? 'caret-down' :''}
+            icon={focused ? selectIconFocused : selectIcon}
             aria-hidden="true"
             role="presentational"
             disabled={disabled || readOnly}


### PR DESCRIPTION
Property for overriding the select icon, primarily allows user to specify an icon to appear when the multiselect is not in focus.