### PR TITLE
fix SASS interpolation

### DIFF
--- a/packages/react-widgets/lessToSass.js
+++ b/packages/react-widgets/lessToSass.js
@@ -8,8 +8,8 @@ let mkdir = require('mkdirp')
 const processors = [
   // interpolated variables
   { pattern: /@\{(?!(\s|\())/g, replace: '#{$' },
-  // literal strings
-  { pattern: /~("|')/g, replace: '$1' },
+  // unwrap escape strings
+  { pattern: /~("|')(.+)\1/g, replace: '$2' },
   // replace variable prefix
   { pattern: /@(?!(media|import|mixin|font-face|keyframes)(\s|\())/g, replace: '$$' },
   // add !default to SCSS variables


### PR DESCRIPTION
The escape strings from LESS need to be unwrapped, otherwise they get output as literal string values in SASS. E.g. `height: "calc(2.429em - 2px)";` instead of the intended `height: calc(2.429em - 2px);`