### PR TITLE
Update DateTimePickerInput.js

### DIFF
--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -363,7 +363,7 @@ class DateTimePicker extends React.Component {
         autoFocus={autoFocus}
         placeholder={placeholder}
         disabled={disabled}
-        readOnly={inputReadOnly || readOnly}
+        readOnly={inputReadOnly !== null ? inputReadOnly : readOnly}
         value={value}
         format={getFormat(this.props)}
         editFormat={editFormat}

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -363,7 +363,7 @@ class DateTimePicker extends React.Component {
         autoFocus={autoFocus}
         placeholder={placeholder}
         disabled={disabled}
-        readOnly={readOnly || inputReadOnly}
+        readOnly={inputReadOnly || readOnly}
         value={value}
         format={getFormat(this.props)}
         editFormat={editFormat}

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -336,7 +336,7 @@ class DateTimePicker extends React.Component {
       name,
       tabIndex,
       autoFocus,
-      inputProps,
+      inputProps = {},
       'aria-labelledby': ariaLabelledby,
       'aria-describedby': ariaDescribedby,
     } = this.props
@@ -350,11 +350,11 @@ class DateTimePicker extends React.Component {
       activeId = this.activeCalendarId
     }
 
-    let {readOnly: inputReadOnly} = inputProps
+    let {readOnly: inputReadOnly, ...otherInputProps} = inputProps
 
     return (
       <DateTimePickerInput
-        {...inputProps}
+        {...otherInputProps}
         id={this.inputId}
         ref={this.attachInputRef}
         role="combobox"

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -350,6 +350,8 @@ class DateTimePicker extends React.Component {
       activeId = this.activeCalendarId
     }
 
+    let {readOnly: inputReadOnly} = inputProps
+
     return (
       <DateTimePickerInput
         {...inputProps}
@@ -361,7 +363,7 @@ class DateTimePicker extends React.Component {
         autoFocus={autoFocus}
         placeholder={placeholder}
         disabled={disabled}
-        readOnly={readOnly}
+        readOnly={readOnly || inputReadOnly}
         value={value}
         format={getFormat(this.props)}
         editFormat={editFormat}

--- a/packages/react-widgets/src/DateTimePickerInput.js
+++ b/packages/react-widgets/src/DateTimePickerInput.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import polyfillLifecycles from 'react-lifecycles-compat'
 import { findDOMNode } from 'react-dom'
+import cn from 'classnames'
 
 import Input from './Input'
 import { date as dateLocalizer } from './util/localizers'
@@ -64,7 +65,7 @@ class DateTimePickerInput extends React.Component {
   }
 
   render() {
-    let { className = '', disabled, readOnly, type = 'text' } = this.props
+    let { className, disabled, readOnly } = this.props
     let { textValue } = this.state
 
     let props = Props.omitOwn(this)
@@ -72,8 +73,8 @@ class DateTimePickerInput extends React.Component {
     return (
       <Input
         {...props}
-        type={type}
-        className={`rw-widget-input ${className}`}
+        type="text"
+        className={cn(className, 'rw-widget-input')}
         value={textValue}
         disabled={disabled}
         readOnly={readOnly}

--- a/packages/react-widgets/src/DateTimePickerInput.js
+++ b/packages/react-widgets/src/DateTimePickerInput.js
@@ -23,6 +23,8 @@ class DateTimePickerInput extends React.Component {
 
     disabled: CustomPropTypes.disabled,
     readOnly: CustomPropTypes.disabled,
+    className: PropTypes.string,
+    type: PropTypes.string
   }
 
   state = {}
@@ -62,7 +64,7 @@ class DateTimePickerInput extends React.Component {
   }
 
   render() {
-    let { disabled, readOnly } = this.props
+    let { className = '', disabled, readOnly, type = 'text' } = this.props
     let { textValue } = this.state
 
     let props = Props.omitOwn(this)
@@ -70,8 +72,8 @@ class DateTimePickerInput extends React.Component {
     return (
       <Input
         {...props}
-        type="text"
-        className="rw-widget-input"
+        type={type}
+        className={`rw-widget-input ${className}`}
         value={textValue}
         disabled={disabled}
         readOnly={readOnly}


### PR DESCRIPTION
> Allow full control over `DateTimePickerInput`'s `<input/>` field props

This update allows the setting of `className` & `type` on the `DateTimePicker`'s input component, via the `inputProps` prop.