### PR TITLE
Fix DateTimePicker current selected time if date is not today

### DIFF
--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -21,33 +21,13 @@ const find = (arr, fn) => {
   return null
 }
 
-function getBounds({ min, max, currentDate, value, preserveDate }) {
-  //compare just the time regradless of whether they fall on the same day
-  if (!preserveDate) {
-    value = value || currentDate || new Date()
-    let start = dates.startOf(
-      dates.merge(value, min, currentDate),
-      'minutes'
-    )
-    let end = dates.startOf(
-      dates.merge(value, max, currentDate),
-      'minutes'
-    )
-
-    if (dates.lte(end, start) && dates.gt(max, min, 'day'))
-      end = dates.tomorrow()
-
-    return {
-      min: start,
-      max: end,
-    }
-  }
+function getBounds({ min, max, currentDate, value }) {
+  value = dates.merge(value, value, currentDate)
   let start = dates.startOf(
-      dates.merge(value, min, currentDate),
-      'minutes'
+      value,
+      'day'
     )
-  let end = dates.merge(dates.add(start, 1, 'day'), max, currentDate)
-  value = value || currentDate || start
+  let end = dates.add(start, 1, 'day')
   //date parts are equal
   return {
     min: dates.eq(value, min, 'day')

--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -24,12 +24,13 @@ const find = (arr, fn) => {
 function getBounds({ min, max, currentDate, value, preserveDate }) {
   //compare just the time regradless of whether they fall on the same day
   if (!preserveDate) {
+    value = value || currentDate || new Date()
     let start = dates.startOf(
-      dates.merge(new Date(), min, currentDate),
+      dates.merge(value, min, currentDate),
       'minutes'
     )
     let end = dates.startOf(
-      dates.merge(new Date(), max, currentDate),
+      dates.merge(value, max, currentDate),
       'minutes'
     )
 
@@ -41,9 +42,11 @@ function getBounds({ min, max, currentDate, value, preserveDate }) {
       max: end,
     }
   }
-
-  let start = dates.today()
-  let end = dates.tomorrow()
+  let start = dates.startOf(
+      dates.merge(value, min, currentDate),
+      'minutes'
+    )
+  let end = dates.merge(dates.add(start, 1, 'day'), max, currentDate)
   value = value || currentDate || start
   //date parts are equal
   return {

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -281,10 +281,14 @@ describe('DateTimePicker', () => {
         <TimeList value={new Date(2014, 0, 18, 8)} min={date} preserveDate />
       )
       time = inst.state('data')[0]
+      console.log(time, time.date)
 
       expect(time.date.getHours()).to.eql(0)
       expect(time.date.getMinutes()).to.eql(0)
       expect(time.date.getSeconds()).to.eql(0)
+      expect(time.date.getMonth()).to.eql(0)
+      expect(time.date.getDate()).to.eql(18)
+      expect(time.date.getFullYear()).to.eql(2014)
     })
 
     it('should set the step property', () => {

--- a/packages/storybook/stories/DateTimePicker.js
+++ b/packages/storybook/stories/DateTimePicker.js
@@ -95,22 +95,29 @@ storiesOf('DateTimePicker', module)
     class Story extends React.Component {
 
       componentDidMount(){
-        this.onChange(new Date(2017, 3, 5, 10, 23))
+        this.onChange(new Date(2014, 0, 18, 8));
       }
 
       onChange = value =>
         this.setState({ value });
 
-      render = () => (
-        <Container>
-          <DateTimePicker
-            date={false}
-            value={this.state && this.state.value}
-            onChange={this.onChange}
-          />
-          <p>Current Value: {this.state && this.state.value.toString()}</p>
-        </Container>
-      )
+      render = () => {
+        const max = new Date(2014, 0, 20, 9, 30);
+        const min = new Date(2014, 0, 16, 9, 30);
+        return (
+          <Container>
+            <DateTimePicker
+              max={max}
+              min={min}
+              onChange={this.onChange}
+              value={this.state && this.state.value}
+            />
+            <p>Minimum Value: {min.toString()}</p>
+            <p>Current Value: {this.state && this.state.value.toString()}</p>
+            <p>Maximum Value: {max.toString()}</p>
+          </Container>
+          )
+      }
     }
 
     return <Story />

--- a/packages/storybook/stories/DateTimePicker.js
+++ b/packages/storybook/stories/DateTimePicker.js
@@ -91,3 +91,29 @@ storiesOf('DateTimePicker', module)
 
     return <Story />
   })
+  .add('date other than today', () => {
+    class Story extends React.Component {
+
+      componentDidMount(){
+        this.onChange(new Date(2017, 3, 5, 10, 23))
+      }
+
+      onChange = value =>
+        this.setState({ value });
+
+      render = () => (
+        <Container>
+          <DateTimePicker
+            date={false}
+            value={this.state && this.state.value}
+            onChange={this.onChange}
+          />
+          <p>Current Value: {this.state && this.state.value.toString()}</p>
+        </Container>
+      )
+    }
+
+    return <Story />
+  }
+    
+  )


### PR DESCRIPTION
If a DateTimePicker has a value that is not equal to today, then the time picker does not scroll to the nearest time value.

This fix resolves that issue and a storyboard has been added to confirm the functionality.