### PR TITLE
css: correct styles to support long placeholders for Multiselect

### DIFF
--- a/packages/react-widgets/src/less/multiselect.less
+++ b/packages/react-widgets/src/less/multiselect.less
@@ -1,3 +1,8 @@
+/**
+  * 1) Correct width for a case when the placeholder is too long and
+  * when some tags were selected
+  */
+
 .rw-multiselect {
   background-color: @widget-bg;
   border-color: @state-border-hover;
@@ -7,8 +12,7 @@
     .height-calc(@input-height, @input-border-width * 2);
 
     border-width: 0;
-    width: auto;
-    max-width: 100%;
+    width: 100%; /* 1 */
     padding: 0 @input-padding-horizontal;
   }
 
@@ -26,6 +30,10 @@
   .unstyled-list();
   display: inline;
   outline: none;
+
+  & + .rw-input-reset { /* 1 */
+    width: auto;
+  }
 }
 
 .rw-multiselect-tag {

--- a/packages/react-widgets/src/less/widget.less
+++ b/packages/react-widgets/src/less/widget.less
@@ -131,6 +131,10 @@
 .rw-input-reset {
   .placeholder();
   outline: 0;
+
+  &[placeholder] {
+    text-overflow: ellipsis;
+  }
 }
 
 .rw-input {


### PR DESCRIPTION
Replacement for https://github.com/jquense/react-widgets/pull/775

Original proposal from @skulden13:

> Hi @jquense,
> I've noticed that the Multiselect control width is too wide on mobile or e.g. when there is a lack of space and a placeholder is too long.
> You could easily repeat this behavior by setting very long placeholder and resize the layout to mobile view.
> That happens because of the size parameter, and the Input has property width: auto.
> As a workaround, I offer to set text-overflow for a placeholder & width: 100% for a blur state of the Multiselect input.
> Thanks, Denis