### PR TITLE
Use simple link for remove button in MultiselectTag component

### DIFF
--- a/packages/react-widgets/src/Button.js
+++ b/packages/react-widgets/src/Button.js
@@ -27,7 +27,7 @@ class Button extends React.Component {
       children,
       variant = 'primary',
       spinner = <Loading />,
-      component: Tag = 'button',
+      component: Tag = 'a',
       ...props
     } = this.props
 

--- a/packages/react-widgets/src/Button.js
+++ b/packages/react-widgets/src/Button.js
@@ -38,6 +38,7 @@ class Button extends React.Component {
     return (
       <Tag
         {...props}
+        role="button"
         tabIndex="-1"
         title={label}
         type={type}

--- a/packages/react-widgets/src/Button.js
+++ b/packages/react-widgets/src/Button.js
@@ -14,6 +14,7 @@ class Button extends React.Component {
     variant: PropTypes.oneOf(['primary', 'select']),
     component: PropTypes.any,
     spinner: PropTypes.node,
+    onClick: PropTypes.func,
   }
 
   render() {
@@ -25,6 +26,7 @@ class Button extends React.Component {
       busy,
       active,
       children,
+      onClick,
       variant = 'primary',
       spinner = <Loading />,
       component: Tag = 'a',
@@ -33,7 +35,13 @@ class Button extends React.Component {
 
     let type = props.type
 
-    if (Tag === 'button') type = type || 'button'
+    if (Tag === 'button') {
+      type = type || 'button'
+    } else {
+      // only "real" buttons are truly disabled in browsers
+      // remove onClick handler in other cases
+      if (disabled && onClick) onClick = null
+    }
 
     return (
       <Tag
@@ -45,6 +53,7 @@ class Button extends React.Component {
         disabled={disabled}
         aria-disabled={disabled}
         aria-label={label}
+        onClick={onClick}
         className={cn(
           className,
           'rw-btn',

--- a/packages/react-widgets/test/Calendar-test.js
+++ b/packages/react-widgets/test/Calendar-test.js
@@ -41,7 +41,7 @@ describe('Calendar', () => {
     let date = new Date()
     let calendar = mount(<Calendar defaultValue={date} />)
 
-    let navBtn = calendar.find('button.rw-calendar-btn-view')
+    let navBtn = calendar.find('a.rw-calendar-btn-view')
 
     calendar.assertSingle(Month);
 
@@ -83,8 +83,8 @@ describe('Calendar', () => {
 
     let calendar = mount(<Calendar defaultValue={date} />)
 
-    let leftBtn = calendar.find('button.rw-calendar-btn-left')
-    let navBtn = calendar.find('button.rw-calendar-btn-view')
+    let leftBtn = calendar.find('a.rw-calendar-btn-left')
+    let navBtn = calendar.find('a.rw-calendar-btn-view')
 
     leftBtn.simulate('click');
 
@@ -129,8 +129,8 @@ describe('Calendar', () => {
       <Calendar defaultValue={date}  max={new Date(2199, 11, 31)} />
     )
 
-    let rightBtn = calendar.find('button.rw-calendar-btn-right')
-    let navBtn = calendar.find('button.rw-calendar-btn-view')
+    let rightBtn = calendar.find('a.rw-calendar-btn-right')
+    let navBtn = calendar.find('a.rw-calendar-btn-view')
 
     rightBtn.simulate('click');
 
@@ -215,7 +215,7 @@ describe('Calendar', () => {
       />
     )
     .find(Footer)
-    .find('button')
+    .find('a')
     .simulate('click')
 
     expect(
@@ -238,12 +238,12 @@ describe('Calendar', () => {
     )
 
     wrapper
-      .find('button.rw-calendar-btn-right')
+      .find('a.rw-calendar-btn-right')
       .tap(inst => inst.is('[disabled]'))
       .simulate('click')
 
     wrapper
-      .find('button.rw-calendar-btn-left')
+      .find('a.rw-calendar-btn-left')
       .tap(inst => inst.is('[disabled]'))
       .simulate('click')
 
@@ -260,7 +260,7 @@ describe('Calendar', () => {
     )
 
     expect(
-      calendar.find('button.rw-calendar-btn-view').contains('junio 2014')
+      calendar.find('a.rw-calendar-btn-view').contains('junio 2014')
     ).to.equal(true)
 
     expect(

--- a/packages/react-widgets/test/Combobox-test.js
+++ b/packages/react-widgets/test/Combobox-test.js
@@ -56,7 +56,7 @@ describe('Combobox', function(){
     let openSpy = sinon.spy();
 
     mount(<ControlledCombobox onToggle={openSpy} />)
-      .find('button')
+      .find('a')
       .first()
       .simulate('click')
 
@@ -68,12 +68,12 @@ describe('Combobox', function(){
     let openSpy = sinon.spy();
 
     mount(<ControlledCombobox onToggle={openSpy} disabled />)
-      .find('button')
+      .find('a')
       .first()
       .simulate('click')
 
     mount(<ControlledCombobox onToggle={openSpy} readOnly />)
-      .find('button')
+      .find('a')
       .first()
       .simulate('click')
 

--- a/packages/react-widgets/test/Multiselect-test.js
+++ b/packages/react-widgets/test/Multiselect-test.js
@@ -241,7 +241,7 @@ describe('Multiselect', function() {
       />
     )
       .find(MultiselectTagList)
-      .assertSingle('li.rw-state-disabled button.rw-multiselect-tag-btn')
+      .assertSingle('li.rw-state-disabled a.rw-multiselect-tag-btn')
       .simulate('click')
 
     expect(change.called).to.equal(false)
@@ -258,7 +258,7 @@ describe('Multiselect', function() {
         data={dataList}
       />
     )
-      .find('button.rw-multiselect-tag-btn')
+      .find('a.rw-multiselect-tag-btn')
       .simulate('click')
 
     expect(changeSpy.called).to.equal(false)
@@ -276,7 +276,7 @@ describe('Multiselect', function() {
         valueField="id"
       />
     )
-      .find('button.rw-multiselect-tag-btn')
+      .find('a.rw-multiselect-tag-btn')
       .first()
       .simulate('click')
 
@@ -294,7 +294,7 @@ describe('Multiselect', function() {
         data={dataList}
       />
     )
-      .find('button.rw-multiselect-tag-btn')
+      .find('a.rw-multiselect-tag-btn')
       .simulate('click')
 
     expect(changeSpy.called).to.equal(false)


### PR DESCRIPTION
Hi!
In our internal project, it's regular practice to wrap a different kind of form elements inside <label> tag to improve accessibility and improve UI. The same happens with autocomplete inputs.
For example
```
<label>
  Select what do you want
  <Multiselect items={[....]} />
</label>
```
Unfortunately, multiselect widget doesn't work well with this kind of layout, because it uses button element for remove button. After clicking on some option in the list of choices the click event is bubbling to the parent label and browser generate click event for the first button element inside label, which is remove button for the just selected option. After that selected option disappears from multiselect list of options.
Another problem - when several values already passed as props inside Multiselect component, clicking on label removes selected options one by one, as it generates clicks on removal buttons.
Here is the minimal example for reproducing browser behavior: https://jsfiddle.net/fph2hhd1/1/ (try click on the label text)
Replacing button with anchor tag is the simplest solution, but it helps. 