### PR TITLE
Updated string regex in lessToSass

### DIFF
--- a/tools/lessToSass.js
+++ b/tools/lessToSass.js
@@ -8,7 +8,7 @@ const processors = [
   // interpolated variables
   { pattern: /@\{(?!(\s|\())/g, replace: '#{$' },
   // literal strings
-  { pattern: /~("|')(.*?)("|')/g, replace: '$2' },
+  { pattern: /~("|')(.*?)\1/g, replace: '$2' },
   // replace variable prefix
   {
     pattern: /@(?!(media|import|mixin|font-face|keyframes)(\s|\())/g,


### PR DESCRIPTION
Replaced second quote match with "\1", so that is only matches the first quote match (so it can match a string like "foo 'bar' baz")