### PR TITLE
SASS web pack conversion calc

### DIFF
--- a/packages/react-widgets/src/less/variables.less
+++ b/packages/react-widgets/src/less/variables.less
@@ -159,9 +159,9 @@
 @multiselect-tag-border:          @btn-border;
 @multiselect-tag-bg:              @gray-lighter;
 @multiselect-tag-height-pt:       1 - (@multiselect-gutter-pt * 2);
-@multiselect-tag-gutter-fallback: @input-height * @multiselect-gutter-pt;
+@multiselect-tag-gutter-fallback: ~"calc(@{input-height} * @{multiselect-gutter-pt})";
 @multiselect-tag-gutter:          ~"calc(@{multiselect-tag-gutter-fallback} - @{input-border-width})";
-@multiselect-tag-height:          @input-height * @multiselect-tag-height-pt;
+@multiselect-tag-height:          ~"calc(@{input-height} * @{multiselect-tag-height-pt})";
 @multiselect-tag-border-radius:   @border-radius-sm;
 
 @multiselect-tag-bg-hover:             @state-bg-hover;

--- a/tools/lessToSass.js
+++ b/tools/lessToSass.js
@@ -24,6 +24,11 @@ const processors = [
     pattern: /^(\s*?)\.([\w\-]*?)\s*\((.*)\)+\s*\{$/gm,
     replace: '$1@mixin $2($3) {',
   },
+  // convert calc
+  {
+    pattern: //gm,
+    replace: '',
+  },
   // convert :extend
   {
     pattern: /^(\s*?)&:extend\((.*)\);?$/,

--- a/tools/lessToSass.js
+++ b/tools/lessToSass.js
@@ -24,11 +24,6 @@ const processors = [
     pattern: /^(\s*?)\.([\w\-]*?)\s*\((.*)\)+\s*\{$/gm,
     replace: '$1@mixin $2($3) {',
   },
-  // convert calc
-  {
-    pattern: //gm,
-    replace: '',
-  },
   // convert :extend
   {
     pattern: /^(\s*?)&:extend\((.*)\);?$/,


### PR DESCRIPTION
I added calc to the LESS file for variables.less
This will convert the LESS file into the right format for SASS on the transpile
Currently the compile for SASS to CSS throws an error for these CSS types to be the same/calcaulated