### PR TITLE
Fix selection/focus of time

### DIFF
--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -42,8 +42,8 @@ function getBounds({ min, max, currentDate, value, preserveDate }) {
     }
   }
 
-  let start = dates.today()
-  let end = dates.tomorrow()
+  let start = dates.startOf(currentDate, 'day')
+  let end = dates.add(start, 1, 'day')
   value = value || currentDate || start
   //date parts are equal
   return {


### PR DESCRIPTION
Calculation of selectedItem and focusedItem was not working because compared values were for different date than currentValue