### PR TITLE
Upgrade localizer-date-fns defaultFormats for date-fns >=2.0.0-alpha.8

### DIFF
--- a/packages/localizer-date-fns/localizer.js
+++ b/packages/localizer-date-fns/localizer.js
@@ -9,7 +9,7 @@ const endOfDecade = addYears(10)
 const endOfCentury = addYears(100)
 
 function getYear(date, culture, localizer) {
-  return localizer.format(date, 'YYYY', culture)
+  return localizer.format(date, 'yyyy', culture)
 }
 
 function decade(date, culture, localizer) {
@@ -29,15 +29,15 @@ function century(date, culture, localizer) {
 }
 
 export const defaultFormats = {
-  date: 'P',
-  time: 'pp',
-  default: 'Pp',
-  header: 'MMMM YYYY',
-  footer: 'PPPP',
-  weekday: 'cccccc',
-  dayOfMonth: 'dd',
-  month: 'MMM',
-  year: 'YYYY',
+  date: 'P',            // 05/29/1453
+  time: 'p',            // 12:00 AM
+  default: 'PP p',      // May 29, 1453 12:00 AM
+  header: 'MMMM yyyy',  // January 1990
+  footer: 'PPPP',       // Sunday, May 29th, 1453
+  weekday: 'EEEEEE',    // Mo, Tu, We, Th, Fr, Su, Sa
+  dayOfMonth: 'dd',     // 01, 02, ..., 31
+  month: 'MMM',         // Jan, Feb, ..., Dec
+  year: 'yyyy',         // 0044, 0001, 1900, 2017
   decade: decade,
   century: century,
 }

--- a/packages/localizer-date-fns/package.json
+++ b/packages/localizer-date-fns/package.json
@@ -30,14 +30,14 @@
   },
   "homepage": "https://github.com/jquense/react-widgets#readme",
   "peerDependencies": {
-    "date-fns": "2.0.0-alpha.13",
+    "date-fns": ">=2.0.0-alpha.8",
     "react-widgets": "^4.2.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.52",
     "@babel/core": "^7.0.0-beta.52",
     "cross-env": "^5.2.0",
-    "date-fns": "^2.0.0-alpha.7",
+    "date-fns": "^2.0.0-alpha.16",
     "react-widgets": "^4.4.3",
     "rimraf": "^2.6.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3687,10 +3687,6 @@ date-fns@^2.0.0-alpha.16:
   version "2.0.0-alpha.16"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.16.tgz#d249a6c9b799252652fb9e3f25460eaf9de86ac7"
 
-date-fns@^2.0.0-alpha.7:
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.9.tgz#1406f2b57107781cf02ad84741a9013990f198ca"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
In [date-fns@2.0.0-alpha.8](https://gist.github.com/kossnocorp/a307a464760b405bb78ef5020a4ab136#v200-alpha8) the date format patterns were changed to match the [Unicode Technical Standard](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table). This brings the `defaultFormats` of the localizer up to date.