### PR TITLE
Fixes #863: force reset of DatePickerInput when date is invalid

### DIFF
--- a/packages/react-widgets/src/DateTimePickerInput.js
+++ b/packages/react-widgets/src/DateTimePickerInput.js
@@ -56,6 +56,10 @@ class DateTimePickerInput extends React.Component {
     if (this._needsFlush) {
       let date = parse(event.target.value)
 
+      const dateIsInvalid = event.target.value != '' && date == null
+      if (dateIsInvalid) {
+        this.setState({ textValue: '' })
+      }
       this._needsFlush = false
       onChange(date, formatDate(date, format, culture))
     }


### PR DESCRIPTION
Fixes #863 AFAICS, this issue seems related to the DateTimePickerInput in the handleBlur method. 

The handleBlur method is in charge of propagating calls to the DateTimePicker.onChange method.
Unfortunately, the DateTimePicker.onChange will not propagate back to the DateTimePickerInput.onChange method since the DateTimePicker does not see any difference between the current value and the new value (they are both null).

This PR tries to fix this by resetting the DateTimePickerInput immediately in case of a parse failure.