### PR TITLE
Allow user to hit enter and select top filtered item

### DIFF
--- a/packages/react-widgets/src/Combobox.js
+++ b/packages/react-widgets/src/Combobox.js
@@ -182,7 +182,7 @@ class Combobox extends React.Component {
       })
     }
     const selectedItem = data[index]
-    const nextFocusedItem = ~focusedIndex ? focusedItem : data[0]
+    const nextFocusedItem = focusedIndex === -1 ? focusedItem : data[focusedIndex]
 
     return {
       data,


### PR DESCRIPTION
fixed edge case where upon hitting enter before using arrows or clicking, the first item out of all options (not just filtered options) was selected by default

For example, where the initial data values are `["a", "aa", "aab", "b"]` with a filter callback like `(el) => el.indexOf(input) !== -1`, and where the filtered values of `input = "b"` are `["aab", "b"], hitting `Return` will return `"a"` instead of `"aab"`.

This change will instead return the top result if the user hits `Return` in the Combobox, as opposed to the very first unfiltered option, and the ability to select with arrows and mouse click is still preserved.
