### PR TITLE
date-fns localizer ensure parse return null when invalid date

### DIFF
--- a/packages/localizer-date-fns/localizer.js
+++ b/packages/localizer-date-fns/localizer.js
@@ -91,12 +91,16 @@ export default function dateFnsLocalizer({
   }
 
   function parse(value, format, culture) {
-    return parseWithOptions(
+    const result = parseWithOptions(
       { locale: getLocale(culture) },
       new Date(),
       format,
       value
     )
+    if (result.toString() === 'Invalid Date') {
+      return null;
+    }
+    return result;
   }
 
   function firstOfWeek(culture) {


### PR DESCRIPTION
I was running into an issue with the date-fns localizer when the user inserted an invalid date. This fixes the issue by checking if parseWithOptions returns 'Invalid Date' and returns null from the parse function instead.