### PR TITLE
Fix 897: Move aria tags to correct place

### DIFF
--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -399,6 +399,9 @@ class DropdownList extends React.Component {
         {filter && (
           <WidgetPicker className="rw-filter-input rw-input">
             <input
+              aria-activedescendant={open ? this.activeId : null}
+              aria-autocomplete="list"
+              aria-controls={open ? this.listId : null}
               value={searchTerm}
               className="rw-input-reset"
               onChange={this.handleInputChange}
@@ -482,12 +485,10 @@ class DropdownList extends React.Component {
       id: this.inputId,
       tabIndex: open && filter ? -1 : tabIndex || 0,
       'aria-owns': this.listId,
-      'aria-activedescendant': open ? this.activeId : null,
       'aria-expanded': !!open,
       'aria-haspopup': true,
       'aria-busy': !!busy,
       'aria-live': !open && 'polite',
-      'aria-autocomplete': 'list',
       'aria-disabled': disabled,
       'aria-readonly': readOnly,
     })


### PR DESCRIPTION
Fixed the aria tags according to the ARIA combobox spec at https://www.w3.org/TR/wai-aria-1.1/#combobox and now the options are being read when navigating by keyboard 