### PR TITLE
Disable autocomplete on Input

### DIFF
--- a/packages/react-widgets/src/Input.js
+++ b/packages/react-widgets/src/Input.js
@@ -29,7 +29,7 @@ function Input({
       type={type}
       ref={nodeRef}
       tabIndex={tabIndex || 0}
-      autoComplete="off"
+      autoComplete="nope"
       disabled={disabled}
       readOnly={readOnly}
       aria-disabled={disabled}


### PR DESCRIPTION
Most modern browsers ignore "off" value for autocomplete. Instead,
the recommended solution is to put a different value for autocomplete
(see e.g. https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164).

Alternative solution could be to make this configurable in props, but seems that the intention is to always disable autocompletion