### PR TITLE
fix: Removed `isRequired` prop type validation from `renderItem` inside `VirtualList`

### DIFF
--- a/packages/virtualized/src/VirtualList.js
+++ b/packages/virtualized/src/VirtualList.js
@@ -32,7 +32,7 @@ class VirtualList extends React.Component {
 
     activeId: PropTypes.string,
     optionComponent: CustomPropTypes.elementType,
-    renderItem: PropTypes.func.isRequired,
+    renderItem: PropTypes.func,
     renderGroup: PropTypes.func,
 
     focusedItem: PropTypes.any,


### PR DESCRIPTION
Since the `VirtualList` code has logic handling a missing `renderItem` (it falls back to either `itemComponent` or `textAccessor`), the prop shouldn't be validated as `isRequired`.