### PR TITLE
Add: render limits to List

### DIFF
--- a/packages/react-widgets/src/List.js
+++ b/packages/react-widgets/src/List.js
@@ -34,10 +34,10 @@ const propTypes = {
   optionComponent: CustomPropTypes.elementType,
   renderItem: PropTypes.func,
   renderGroup: PropTypes.func,
+  renderLimit: PropTypes.number,
 
   focusedItem: PropTypes.any,
   selectedItem: PropTypes.any,
-  searchTerm: PropTypes.string,
 
   isDisabled: PropTypes.func.isRequired,
 
@@ -65,8 +65,13 @@ class List extends React.Component {
   }
 
   mapItems(fn) {
-    const { data, dataState } = this.props
+    const { dataState, renderLimit } = this.props
+    let { data } = this.props;
     let { sortedKeys, groups } = dataState
+
+    if (renderLimit) {
+      data = data.slice(0, renderLimit);
+    }
 
     if (!groups) return data.map((item, idx) => fn(item, idx, false))
 


### PR DESCRIPTION
Use-case:
Let's say you use the Combobox. The Combobox search is fast at filtering the data even with a large array with several thousand items. However, rendering this list initially puts a lot of stress on the browser. It's not very useful to have a several thousand items long list anyway.
By adding a render limit, we can keep the search over all items while rendering only a useful amount of them.
This change is necessary to do inside `<List />` because slicing the data outside would break the search.