### PR TITLE
Add onDelete callback prop to Multiselect, called on tag item deletion

### DIFF
--- a/packages/react-widgets/src/Multiselect.js
+++ b/packages/react-widgets/src/Multiselect.js
@@ -73,6 +73,7 @@ let propTypes = {
 
   open: PropTypes.bool,
   onToggle: PropTypes.func,
+  onDelete: PropTypes.func,
   //-------------------------------------------
 
   valueField: CustomPropTypes.accessor,
@@ -264,6 +265,8 @@ class Multiselect extends React.Component {
     let { disabled, readOnly } = this.props
 
     if (disabled == true || readOnly) return
+
+    notify(this.props.onDelete, [dataItem, event])
 
     this.focus()
     this.change(dataItem, event, REMOVE)

--- a/www/language.js
+++ b/www/language.js
@@ -166,6 +166,13 @@ module.exports = {
     Use in conjunction with the \`open\` prop to manually control the popup visibility.
   `,
 
+  onDelete: d => stripIndent`
+    A callback fired when ${d.name}'s contained item is about to be deleted.
+    Given the item and the DOM event as arguments.
+
+    Can be used for example to prevent event propagation on item deletion.
+  `,
+
   busy: () => stripIndent`
     Controls the loading/busy spinner visibility. Presentational only! Useful
     for providing visual feedback while data is being loaded.


### PR DESCRIPTION
The callback is given two arguments: the tag item and the event from the "cross"
delete-item button. This allows the client code, among other things, to prevent event
propagation to the Multiselect control itself. This can be useful for e.g. preventing
the drop down list from opening when a tag item is deleted.

Use case: one may find it undesirable that on an item deletion, Multiselect's drop down opens every time. Preventing event propagation changes this default behavior.