### PR TITLE
fix: focusedItem logic to better handle boolean dropdownlists item values

### DIFF
--- a/packages/react-widgets/src/Combobox.js
+++ b/packages/react-widgets/src/Combobox.js
@@ -187,7 +187,7 @@ class Combobox extends React.Component {
     let nextFocusedItem = null
     // If no item is focused, or is no longer in the dataset, default to either the selected item, or to the first item in the list
     if (focusedIndex === -1) {
-      if (selectedItem) {
+      if (selectedItem !== undefined) {
         nextFocusedItem = selectedItem
       } else {
         nextFocusedItem = data[0]
@@ -207,8 +207,8 @@ class Combobox extends React.Component {
         ? list.nextEnabled(selectedItem)
         : prevState.selectedItem,
       focusedItem:
-        (valueChanged || !focusedItem)
-          ? list.nextEnabled(selectedItem || nextFocusedItem)
+        (valueChanged || focusedItem === undefined)
+          ? list.nextEnabled(selectedItem !== undefined ? selectedItem : nextFocusedItem)
           : nextFocusedItem,
     }
   }

--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -205,8 +205,8 @@ class DropdownList extends React.Component {
         ? list.nextEnabled(selectedItem)
         : prevState.selectedItem,
       focusedItem:
-        valueChanged || focusedItem === undefined
-          ? list.nextEnabled(selectedItem)
+        (valueChanged || focusedItem === undefined)
+          ? list.nextEnabled(selectedItem !== undefined ? selectedItem : nextFocusedItem)
           : nextFocusedItem,
     }
   }

--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -205,8 +205,8 @@ class DropdownList extends React.Component {
         ? list.nextEnabled(selectedItem)
         : prevState.selectedItem,
       focusedItem:
-        valueChanged || !focusedItem
-          ? list.nextEnabled(selectedItem || nextFocusedItem)
+        valueChanged || focusedItem === undefined
+          ? list.nextEnabled(selectedItem)
           : nextFocusedItem,
     }
   }

--- a/packages/react-widgets/src/Multiselect.js
+++ b/packages/react-widgets/src/Multiselect.js
@@ -245,7 +245,7 @@ class Multiselect extends React.Component {
         ? list.nextEnabled(~dataItems.indexOf(focusedTag) ? focusedTag : null)
         : focusedTag,
       focusedItem:
-        valueChanged || !prevState.focusedItem
+        valueChanged || prevState.focusedItem === undefined
           ? list.nextEnabled(nextFocusedItem)
           : nextFocusedItem,
     }


### PR DESCRIPTION
Previously, DropdownLists did a straightup boolean check on `focusedItem`, causing unexpected default focus behavior in cases where an option had a falsey value and wasn't first in the list.

To recreate:
Generate a dropdown list with `false` as an option value in a position other than first. Select `false` from your list. On reload, the page will display `false` as the selected item, but default to the first option as the focused item.