### PR TITLE
Simple fix to #938. Opens up a question about data-flow.

### DIFF
--- a/packages/react-widgets/src/DateTimePicker/DateTimePickerInput.js
+++ b/packages/react-widgets/src/DateTimePicker/DateTimePickerInput.js
@@ -3,11 +3,15 @@ import React from 'react'
 import { polyfill as polyfillLifecycles } from 'react-lifecycles-compat'
 import { findDOMNode } from 'react-dom'
 
-import Input from './Input'
-import { date as dateLocalizer } from './util/localizers'
-import * as CustomPropTypes from './util/PropTypes'
-import * as Props from './util/Props'
+import Input from '../Input'
+import { date as dateLocalizer } from '../util/localizers'
+import * as CustomPropTypes from '../util/PropTypes'
+import * as Props from '../util/Props'
 
+/**
+ * Input that allows the date-time to be directly edited
+ * using the keyboard.
+ */
 @polyfillLifecycles
 class DateTimePickerInput extends React.Component {
   static propTypes = {
@@ -26,6 +30,13 @@ class DateTimePickerInput extends React.Component {
   }
 
   state = {}
+
+  /**
+   * To be set whenever this input's text is altered; it
+   * lifts the new DateTime to the parent by calling
+   * {@code onChange}.
+   */
+  _needFlush = false
 
   static getDerivedStateFromProps(nextProps, prevState) {
     let { value, editing, editFormat, format, culture } = nextProps
@@ -57,11 +68,20 @@ class DateTimePickerInput extends React.Component {
       let date = parse(event.target.value)
 
       const dateIsInvalid = event.target.value != '' && date == null
-      if (dateIsInvalid) {
-        this.setState({ textValue: '' })
-      }
       this._needsFlush = false
-      onChange(date, formatDate(date, format, culture))
+
+      if (dateIsInvalid) {
+        this.setState({
+          textValue: formatDate(
+            this.props.value,
+            this.props.editing && this.props.editFormat ?
+              this.props.editFormat : this.props.format,
+            this.props.culture
+          )
+        })
+      } else {
+        onChange(date, formatDate(date, format, culture))
+      }
     }
   }
 

--- a/packages/react-widgets/src/DateTimePicker/index.js
+++ b/packages/react-widgets/src/DateTimePicker/index.js
@@ -8,25 +8,25 @@ import cn from 'classnames'
 import deprecated from 'prop-types-extra/lib/deprecated'
 import uncontrollable from 'uncontrollable'
 
-import Widget from './Widget'
-import WidgetPicker from './WidgetPicker'
-import Popup from './Popup'
-import Button from './Button'
-import Calendar from './Calendar'
+import Widget from '../Widget'
+import WidgetPicker from '../WidgetPicker'
+import Popup from '../Popup'
+import Button from '../Button'
+import Calendar from '../Calendar'
 import DateTimePickerInput from './DateTimePickerInput'
-import Select from './Select'
-import TimeList from './TimeList'
-import { getMessages } from './messages'
+import Select from '../Select'
+import TimeList from '../TimeList'
+import { getMessages } from '../messages'
 
-import * as Props from './util/Props'
-import * as CustomPropTypes from './util/PropTypes'
-import focusManager from './util/focusManager'
-import scrollManager from './util/scrollManager'
-import { widgetEditable } from './util/interaction'
-import dates from './util/dates'
-import { date as dateLocalizer } from './util/localizers'
-import { instanceId, notify, isFirstFocusedRender } from './util/widgetHelpers'
-import { calendar, clock } from './Icon'
+import * as Props from '../util/Props'
+import * as CustomPropTypes from '../util/PropTypes'
+import focusManager from '../util/focusManager'
+import scrollManager from '../util/scrollManager'
+import { widgetEditable } from '../util/interaction'
+import dates from '../util/dates'
+import { date as dateLocalizer } from '../util/localizers'
+import { instanceId, notify, isFirstFocusedRender } from '../util/widgetHelpers'
+import { calendar, clock } from '../Icon'
 
 let NEXT_VIEW = {
   date: 'time',
@@ -55,29 +55,37 @@ let propTypes = {
   onToggle: PropTypes.func,
 
   /**
-   * Default current date at which the calendar opens. If none is provided, opens at today's date or the `value` date (if any).
+   * Default current date at which the calendar opens. If
+   * none is provided, opens at today's date or the `value`
+   * date (if any).
    */
   currentDate: PropTypes.instanceOf(Date),
 
   /**
-   * Change event Handler that is called when the currentDate is changed. The handler is called with the currentDate object.
+   * Change event Handler that is called when the currentDate
+   * is changed. The handler is called with the {@code currentDate}
+   * object.
    */
   onCurrentDateChange: PropTypes.func,
   onSelect: PropTypes.func,
 
   /**
-   * The minimum Date that can be selected. Min only limits selection, it doesn't constrain the date values that
-   * can be typed or pasted into the widget. If you need this behavior you can constrain values via
-   * the `onChange` handler.
+   * The minimum date that can be selected. Min only limits
+   * selection, it doesn't constrain the date values that can
+   * be typed or pasted into the widget. If you need this
+   * behavior you can constrain values via the `onChange`
+   * handler.
    *
    * @example ['prop', ['min', 'new Date()']]
    */
   min: PropTypes.instanceOf(Date),
 
   /**
-   * The maximum Date that can be selected. Max only limits selection, it doesn't constrain the date values that
-   * can be typed or pasted into the widget. If you need this behavior you can constrain values via
-   * the `onChange` handler.
+   * The maximum date that can be selected. Max only limits
+   * selection, it doesn't constrain the date values that
+   * can be typed or pasted into the widget. If you need
+   * this behavior you can constrain values via the `onChange`
+   * handler.
    *
    * @example ['prop', ['max', 'new Date()']]
    */
@@ -93,15 +101,17 @@ let propTypes = {
   culture: PropTypes.string,
 
   /**
-   * A formatter used to display the date value. For more information about formats
-   * visit the [Localization page](/localization)
+   * A formatter used to display the date value. For more
+   * information about formats, visit
+   * the [Localization page](/localization)
    *
    * @example ['dateFormat', ['format', "{ raw: 'MMM dd, yyyy' }", null, { defaultValue: 'new Date()', time: 'false' }]]
    */
   format: CustomPropTypes.dateFormat,
 
   /**
-   * A formatter used by the time dropdown to render times. For more information about formats visit
+   * A formatter used by the time dropdown to render
+   * times. For more information about formats, visit
    * the [Localization page](/localization).
    *
    * @example ['dateFormat', ['timeFormat', "{ time: 'medium' }", null, { date: 'false', open: '"time"' }]]
@@ -109,8 +119,10 @@ let propTypes = {
   timeFormat: CustomPropTypes.dateFormat,
 
   /**
-   * A formatter to be used while the date input has focus. Useful for showing a simpler format for inputing.
-   * For more information about formats visit the [Localization page](/localization)
+   * A formatter to be used while the date input has focus.
+   * Useful for showing a simpler format for inputing. For
+   * more information about formats, visit
+   * the [Localization page](/localization)
    *
    * @example ['dateFormat', ['editFormat', "{ date: 'short' }", null, { defaultValue: 'new Date()', format: "{ raw: 'MMM dd, yyyy' }", time: 'false' }]]
    */
@@ -130,14 +142,21 @@ let propTypes = {
   calendar: deprecated(PropTypes.bool, 'Use `date` instead'),
 
   /**
-   * A customize the rendering of times but providing a custom component.
+   * A customize the rendering of times but providing a
+   * custom component.
    */
   timeComponent: CustomPropTypes.elementType,
 
-  /** Specify the element used to render the calendar dropdown icon. */
+  /**
+   * Specify the element used to render the calendar dropdown
+   * icon.
+   */
   dateIcon: PropTypes.node,
 
-  /** Specify the element used to render the time list dropdown icon. */
+  /**
+   * Specify the element used to render the time list dropdown
+   * icon.
+   */
   timeIcon: PropTypes.node,
 
   dropUp: PropTypes.bool,
@@ -146,19 +165,24 @@ let propTypes = {
   placeholder: PropTypes.string,
   name: PropTypes.string,
   autoFocus: PropTypes.bool,
+
   /**
    * @example ['disabled', ['new Date()']]
    */
   disabled: CustomPropTypes.disabled,
+
   /**
    * @example ['readOnly', ['new Date()']]
    */
   readOnly: CustomPropTypes.disabled,
 
   /**
-   * Determines how the widget parses the typed date string into a Date object. You can provide an array of formats to try,
-   * or provide a function that returns a date to handle parsing yourself. When `parse` is unspecified and
-   * the `format` prop is a `string` parse will automatically use that format as its default.
+   * Determines how the widget parses the typed date string
+   * into a Date object. You can provide an array of formats
+   * to try, or provide a function that returns a date to
+   * handle parsing yourself. When `parse` is unspecified and
+   * the `format` prop is a `string` parse will automatically
+   * use that format as its default.
    */
   parse: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
@@ -243,6 +267,7 @@ class DateTimePicker extends React.Component {
     this.state = {
       focused: false,
       messages: getMessages(this.props.messages),
+
     }
   }
 
@@ -254,13 +279,12 @@ class DateTimePicker extends React.Component {
   handleChange = (date, str, constrain) => {
     let { onChange, value } = this.props
 
-    if (constrain) date = this.inRangeValue(date)
+    if (constrain)
+      date = this.inRangeValue(date)
 
     if (onChange) {
       if (date == null || value == null) {
-        if (
-          date != value //eslint-disable-line eqeqeq
-        )
+        if (date != value /* eslint-disable-line eqeqeq*/)
           onChange(date, str)
       } else if (!dates.eq(date, value)) {
         onChange(date, str)
@@ -274,10 +298,12 @@ class DateTimePicker extends React.Component {
 
     notify(onKeyDown, [e])
 
-    if (e.defaultPrevented) return
+    if (e.defaultPrevented)
+      return
 
-    if (e.key === 'Escape' && open) this.close()
-    else if (e.altKey) {
+    if (e.key === 'Escape' && open) {
+      this.close()
+    } else if (e.altKey) {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
         this.open()
@@ -286,8 +312,10 @@ class DateTimePicker extends React.Component {
         this.close()
       }
     } else if (open) {
-      if (open === 'date') this.calRef.inner.handleKeyDown(e)
-      if (open === 'time') this.timeRef.handleKeyDown(e)
+      if (open === 'date')
+        this.calRef.inner.handleKeyDown(e)
+      if (open === 'time')
+        this.timeRef.handleKeyDown(e)
     }
   }
 

--- a/packages/react-widgets/src/Widget.js
+++ b/packages/react-widgets/src/Widget.js
@@ -32,7 +32,7 @@ class Widget extends React.Component {
       ...props
     } = this.props
 
-    tabIndex = tabIndex != null ? tabIndex : '-1'
+    tabIndex = (tabIndex != null) ? tabIndex : '-1'
 
     return (
       <div


### PR DESCRIPTION
1. Fixed structure for `DateTimePicker` by moving `DateTimePicker.js` and `DateTimePickerInput.js` into a new folder `DateTimePicker` (renamed `DateTimePicker.js` to `index.js`).

2. Fixed #938 by making the `DateTimePickerInput` component revert to the previous `DateTime`, if the new `DateTime` is invalid/cannot-be-parsed; however, this questions our data-flow.

**Data-Flow problem that needs discussion:** 

* Previous data-flow: `DateTimePickerInput` would always call `onChange` whenever the user blurred the `DateTimePickerInput` component, i.e. clicked outside. However, some applications may want updates whenever the user changes the `DateTime`, without having to click outside. Due to the implementation of `DTPInput`, that use-case cannot be fulfilled.

* New data-flow: `DateTimePickerInput` still calls `onChange` whenever it is blurred; however, it won't if the `DateTime` is invalid - this allows the parent to assume that `onChange` will never be called with `null` as the `date`. However, it still poses a problem of "which" `DateTime` to revert to.

My fix makes the `DTPInput` revert to the `DateTime` as set in the props by the parent. However, the user may not want that, as I'll show with these reproduction steps:

1. Let's say that the current-date is "Jan 26, 1998 12:12:12 PM".

2. The user clicks on the `DTPInput` and edit it to be "Jan 27, ..."; but he doesn't click outside (hence, `onChange` isn't called).

3. The user now accidentally presses "s" making the text "Jan 27s, ...", which is invalid, and then clicks outside.

(NOTE: `DTPInput` is a shorthand for `DateTimePickerInput`).

**Expected:** User wants the component to revert to "Jan 27, ...".

**Actual:** Component reverts to the original "Jan 26, ...".

**Fix:** 

1. This could be fixed by calling `onChange` whenever the user edits the text (not just when loosing focus) and the new `DateTime` is valid. We could add a prop to `DateTimePicker` to prevent this behavior called `liftPartialDates` or `liftInProgressDates`.

OR

2. We could store the `previousValidDate` in the state of `DateTimePickerInput`.