### PR TITLE
Fix typo in site

### DIFF
--- a/www/src/components/PropHeader.js
+++ b/www/src/components/PropHeader.js
@@ -10,7 +10,7 @@ import Type from './Type';
 
 const controllableProps = {
   value: 'onChange',
-  searchTerm: 'onSeach',
+  searchTerm: 'onSearch',
   open: 'onToggle',
   currentDate: 'onCurrentDateChange',
 }


### PR DESCRIPTION
Fix typo `onSeach` -> `onSearch` in documentation site.
![image](https://user-images.githubusercontent.com/16452789/61175359-a9a05a00-a5b6-11e9-89d1-b6c2bea7a5de.png)
