### PR TITLE
feat(DateTimePicker): Support "preventScroll" option for focus()

### DIFF
--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -143,6 +143,9 @@ let propTypes = {
   dropUp: PropTypes.bool,
   popupTransition: CustomPropTypes.elementType,
 
+  /** Prevent the window scrolling to the top when datepicker is focused */
+  preventScroll: PropTypes.bool,
+
   placeholder: PropTypes.string,
   name: PropTypes.string,
   autoFocus: PropTypes.bool,
@@ -222,6 +225,7 @@ class DateTimePicker extends React.Component {
     open: false,
     dateIcon: calendar,
     timeIcon: clock,
+    preventScroll: false,
   }
 
   constructor(...args) {
@@ -580,8 +584,9 @@ class DateTimePicker extends React.Component {
   }
 
   focus() {
+    const { preventScroll } = this.props;
     if (this.inputRef && activeElement() !== findDOMNode(this.inputRef))
-      this.inputRef.focus()
+      this.inputRef.focus({ preventScroll })
   }
 
   parse = string => {

--- a/packages/react-widgets/src/DateTimePickerInput.js
+++ b/packages/react-widgets/src/DateTimePickerInput.js
@@ -44,8 +44,8 @@ class DateTimePickerInput extends React.Component {
     return null
   }
 
-  focus() {
-    findDOMNode(this).focus()
+  focus({ preventScroll = false }) {
+    findDOMNode(this).focus({ preventScroll });
   }
 
   handleBlur = event => {


### PR DESCRIPTION
Because of the default behavior of "focus()", when the visible area is limited and can be scrolled, then if users do any operation that could eventually trigger the "focus()" method, it will scroll to the top, which is not good for user experience in some cases.

Fortunately, an extra option `preventScroll` is provided according to the latest specification (Refer to: https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus). By enabling this option, we could do less work and easily fix the problem. Also, the compatibility looks not so bad.

So I would like to open this pull request to ask for supporting this option.

Thanks!