### PR TITLE
Pass navigatePrevIcon & navigateNextIcon props to Calendar Header

### DIFF
--- a/packages/react-widgets/src/Calendar.js
+++ b/packages/react-widgets/src/Calendar.js
@@ -446,6 +446,8 @@ class Calendar extends React.Component {
       max,
       culture,
       tabIndex,
+      navigatePrevIcon,
+      navigateNextIcon
     } = this.props
 
     let { currentDate, view, slideDirection, focused, messages } = this.state
@@ -490,6 +492,8 @@ class Calendar extends React.Component {
           onViewChange={this.handleViewChange}
           onMoveLeft={this.handleMoveBack}
           onMoveRight={this.handleMoveForward}
+          navigatePrevIcon={navigatePrevIcon}
+          navigateNextIcon={navigateNextIcon}
         />
         <Calendar.Transition direction={slideDirection}>
           <View


### PR DESCRIPTION
These props currently have no effect due to them not being passed from the Calendar down to the Header where they need to be used, resulting in the default values being used instead of the ones defined by the Calendar props.

Fixes #896.