### PR TITLE
implement availableTimes property for DateTimePicker

### DIFF
--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -134,6 +134,17 @@ let propTypes = {
    */
   timeComponent: CustomPropTypes.elementType,
 
+  /**
+   * Customize available time range for time select, includeLastStep defines whether last
+   * time element will be in time range list
+   *
+   * @example { hours: [8, 9, 10], includeLastStep: true }
+   */
+  availableTimes: PropTypes.shape({
+    hours: PropTypes.arrayOf(PropTypes.number),
+    includeLastStep: PropTypes.bool
+  }),
+
   /** Specify the element used to render the calendar dropdown icon. */
   dateIcon: PropTypes.node,
 
@@ -490,6 +501,7 @@ class DateTimePicker extends React.Component {
       timeComponent,
       timeListProps,
       popupTransition,
+      availableTimes
     } = this.props
 
     return (
@@ -505,6 +517,7 @@ class DateTimePicker extends React.Component {
             min={min}
             max={max}
             step={step}
+            availableTimes={availableTimes}
             listProps={timeListProps}
             currentDate={currentDate}
             activeId={activeOptionId}

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -318,5 +318,34 @@ describe('DateTimePicker', () => {
       expect(dates[1].date.getHours()).to.equal(2)
       expect(dates[2].date.getHours()).to.equal(4)
     })
+
+    it('should set availableTimes property', () => {
+      let availableTimes = {
+        hours: [8, 9]
+      }
+      let dates = mount(<DateTimePicker availableTimes={availableTimes} />)
+        .find(TimeList)
+        .instance().state.data
+
+      expect(dates.length).to.equal(3)
+      expect(dates[0].date.getHours()).to.equal(8)
+      expect(dates[1].date.getHours()).to.equal(8)
+      expect(dates[2].date.getHours()).to.equal(9)
+
+      availableTimes = {
+        hours: [8, 9],
+        includeLastStep: true
+      }
+
+      dates = mount(<DateTimePicker availableTimes={availableTimes} />)
+        .find(TimeList)
+        .instance().state.data
+
+      expect(dates.length).to.equal(4)
+      expect(dates[0].date.getHours()).to.equal(8)
+      expect(dates[1].date.getHours()).to.equal(8)
+      expect(dates[2].date.getHours()).to.equal(9)
+      expect(dates[3].date.getHours()).to.equal(9)
+    })
   })
 })


### PR DESCRIPTION
Hello!

I needed one feature for my work project, so I implemented this in your library.
Business task was set like so:

> Person need to select time only in working hours e.g. (8 AM - 8 PM)

As I couldn't achieve it by `timeComponent`, because it renders empty `li` tags that can be clicked, I modified `getDates` function in order to achieve this goal.
Hope you will find my PR useful