### PR TITLE
docs: Update react-widgets packge.json docs url

### DIFF
--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -48,7 +48,7 @@
     "build": "npm run build:lib && npm run build:dist",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "http://jquense.github.io/react-widgets/docs/",
+  "homepage": "https://jquense.github.io/react-widgets/",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the url to the 'homepage' on NPM: https://www.npmjs.com/package/react-widgets

Currently pointing at http://jquense.github.io/react-widgets/docs/, which 404s.