### PR TITLE
TimeList should compare date values relative to currently selected day when seeding focus for time value

### DIFF
--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -124,8 +124,8 @@ class TimeList extends React.Component {
         currentValue.getDate()
       )
 
-      const diff = dates.diff(t.date, currentValue, 'minutes')
-      // const diff2 = dates.diff(relativeDate, currentValue, 'minutes')
+      const diff2 = dates.diff(relativeDate, currentValue, 'minutes')
+      // const diff = dates.diff(t.date, currentValue, 'minutes')
 
       // console.log(
       //   'comparison date',

--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -124,19 +124,8 @@ class TimeList extends React.Component {
         currentValue.getDate()
       )
 
-      const diff2 = dates.diff(relativeDate, currentValue, 'minutes')
-      // const diff = dates.diff(t.date, currentValue, 'minutes')
-
-      // console.log(
-      //   'comparison date',
-      //   '\n orignal date  \t', t.date,
-      //   '\n relative date \t', relativeDate,
-      //   '\n current date  \t', currentValue,
-      //   '\n original diff \t', diff,
-      //   '\n relative diff \t', diff2
-      // )
-
-      return Math.abs(diff2) < step
+      const diff = dates.diff(relativeDate, currentValue, 'minutes')
+      return Math.abs(diff) < step
     });
 
     return {

--- a/packages/react-widgets/src/TimeList.js
+++ b/packages/react-widgets/src/TimeList.js
@@ -114,10 +114,30 @@ class TimeList extends React.Component {
     let selectedItem = find(data, t =>
       dates.eq(t.date, currentValue, 'minutes')
     )
-    let closestDate = find(
-      data,
-      t => Math.abs(dates.diff(t.date, currentValue, 'minutes')) < step
-    )
+
+    let closestDate = find(data, t => {
+      let relativeDate = new Date(t.date)
+
+      relativeDate.setFullYear(
+        currentValue.getFullYear(),
+        currentValue.getMonth(),
+        currentValue.getDate()
+      )
+
+      const diff = dates.diff(t.date, currentValue, 'minutes')
+      // const diff2 = dates.diff(relativeDate, currentValue, 'minutes')
+
+      // console.log(
+      //   'comparison date',
+      //   '\n orignal date  \t', t.date,
+      //   '\n relative date \t', relativeDate,
+      //   '\n current date  \t', currentValue,
+      //   '\n original diff \t', diff,
+      //   '\n relative diff \t', diff2
+      // )
+
+      return Math.abs(diff2) < step
+    });
 
     return {
       data,
@@ -128,8 +148,8 @@ class TimeList extends React.Component {
         valueChanged || !prevState.focusedItem
           ? list.nextEnabled(selectedItem || closestDate || data[0])
           : find(data, t =>
-              dates.eq(t.date, prevState.focusedItem.date, 'minutes')
-            ),
+            dates.eq(t.date, prevState.focusedItem.date, 'minutes')
+          ),
     }
   }
 


### PR DESCRIPTION
Currently the TimeList does not auto focus after selecting a date other than the current day. This causes  the time dropdown to focus on the first item in the list when there is not currently selected item in the dropdown (either 0:00 or 12:00 AM).  

The main cause of this issue is that when attempting to find the closest date, it compares the difference between the currently selected day, and a previous initialized values in the data list based on the current date. This value is then compared to step. This logic results in a closest date not being found since the diff is almost always greater than the step value.

This PR is a focused change to the TimeList component. An argument can made that this change can be made in the getBounds call, or in the date-arithmetic (when diffing minutes) pkg. Both of these options would have wide spread implications. Considering performance implications, step values has a minimum value of 1, which translates to a maximum of 1440 items in the list for the most extreme case.