### PR TITLE
SelectList .next called on undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "react-widgets",
   "private": true,
   "engines": {
     "yarn": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "react-widgets",
   "private": true,
   "engines": {
     "yarn": "^1.0.0",

--- a/packages/react-widgets/src/SelectList.js
+++ b/packages/react-widgets/src/SelectList.js
@@ -380,7 +380,7 @@ class SelectList extends React.Component {
   }
 
   search(character, originalEvent) {
-    let { _searchTerm, list } = this
+    let { _searchTerm, state: { list } } = this
 
     let word = ((_searchTerm || '') + character).toLowerCase()
     let multiple = this.props.multiple


### PR DESCRIPTION
SelectList: fixed "call .next in undefined" while search being focused on SelectList (multivalues, if important). Error was thrown to console, you can easily to reproduce it. Thx a lot for useful lib!