### PR TITLE
fix: undefined originalEvent on change list item

### DIFF
--- a/packages/react-widgets/src/SelectListItem.js
+++ b/packages/react-widgets/src/SelectListItem.js
@@ -20,7 +20,7 @@ class SelectListItem extends React.Component {
     let { onChange, disabled, dataItem } = this.props;
 
     if (!disabled)
-      onChange(dataItem, e.target.checked)
+      onChange(dataItem, e.target.checked, e)
   };
 
   render() {


### PR DESCRIPTION
input not passing the originalEvent to onChange, so it is always undefined
```
export const TestComponent = memo(() => {
  async function onComponentChange(value, { originalEvent }) {
    console.log('event :', originalEvent);
    setTouched({ [name]: true });
    await setFieldValue(name, value.id);
    onChange(value.id);
  }

  return(
      <SelectList
        data={data}
        name={name}
        textField={name}
        itemComponent={ExampleComponent}
        onChange={onComponentChange}
      />
  )
})
```