### PR TITLE
fix: enforce type=button on AddToListOption

### DIFF
--- a/packages/react-widgets/src/AddToListOption.tsx
+++ b/packages/react-widgets/src/AddToListOption.tsx
@@ -32,6 +32,7 @@ function AddToListOption({
       data-rw-focused={focused ? '' : undefined}
       className={cn('rw-list-option-create', focused && 'rw-state-focus')}
       onClick={onSelect}
+      type="button"
       {...props}
     >
       {children}


### PR DESCRIPTION
Prevents the "create option" button from submitting the underlying form