### PR TITLE
DateTimePicker - use the given input id prop as is, instead of suffixing with '_input

### DIFF
--- a/packages/react-widgets/src/Combobox.js
+++ b/packages/react-widgets/src/Combobox.js
@@ -310,6 +310,7 @@ class Combobox extends React.Component {
     } = this.props
     let { accessors } = this.state
     let valueItem = accessors.findOrSelf(data, value)
+    const resovledInputId = inputProps?.id || this.inputId
 
     let completeType = suggest
       ? filter
@@ -324,7 +325,7 @@ class Combobox extends React.Component {
         {...inputProps}
         role="combobox"
         name={name}
-        id={this.inputId}
+        id={resovledInputId}
         autoFocus={autoFocus}
         tabIndex={tabIndex}
         suggest={suggest}

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -227,7 +227,7 @@ class DateTimePicker extends React.Component {
   constructor(...args) {
     super(...args)
 
-    this.inputId = instanceId(this, '_input')
+    this.inputId = this.props.id || instanceId(this, '_input')
     this.dateId = instanceId(this, '_date')
     this.listId = instanceId(this, '_listbox')
     this.activeCalendarId = instanceId(this, '_calendar_active_cell')

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -25,7 +25,7 @@ import scrollManager from './util/scrollManager'
 import { widgetEditable } from './util/interaction'
 import dates from './util/dates'
 import { date as dateLocalizer } from './util/localizers'
-import { instanceId, notify, isFirstFocusedRender } from './util/widgetHelpers'
+import { instanceId, notify, isFirstFocusedRender, hasValidCustomInputId } from './util/widgetHelpers'
 import { calendar, clock } from './Icon'
 
 let NEXT_VIEW = {
@@ -227,7 +227,7 @@ class DateTimePicker extends React.Component {
   constructor(...args) {
     super(...args)
 
-    this.inputId = this.props.id || instanceId(this, '_input')
+    this.inputId = instanceId(this, '_input')
     this.dateId = instanceId(this, '_date')
     this.listId = instanceId(this, '_listbox')
     this.activeCalendarId = instanceId(this, '_calendar_active_cell')
@@ -360,6 +360,7 @@ class DateTimePicker extends React.Component {
       'aria-labelledby': ariaLabelledby,
       'aria-describedby': ariaDescribedby,
     } = this.props
+    const resovledInputId = hasValidCustomInputId(inputProps) ? inputProps.id : this.inputId;
 
     let { focused } = this.state
     let inputReadOnly = inputProps ? inputProps.readOnly : null
@@ -374,7 +375,7 @@ class DateTimePicker extends React.Component {
     return (
       <DateTimePickerInput
         {...inputProps}
-        id={this.inputId}
+        id={resovledInputId}
         ref={this.attachInputRef}
         role="combobox"
         name={name}

--- a/packages/react-widgets/src/DateTimePicker.js
+++ b/packages/react-widgets/src/DateTimePicker.js
@@ -25,7 +25,7 @@ import scrollManager from './util/scrollManager'
 import { widgetEditable } from './util/interaction'
 import dates from './util/dates'
 import { date as dateLocalizer } from './util/localizers'
-import { instanceId, notify, isFirstFocusedRender, hasValidCustomInputId } from './util/widgetHelpers'
+import { instanceId, notify, isFirstFocusedRender } from './util/widgetHelpers'
 import { calendar, clock } from './Icon'
 
 let NEXT_VIEW = {
@@ -360,7 +360,7 @@ class DateTimePicker extends React.Component {
       'aria-labelledby': ariaLabelledby,
       'aria-describedby': ariaDescribedby,
     } = this.props
-    const resovledInputId = hasValidCustomInputId(inputProps) ? inputProps.id : this.inputId;
+    const resovledInputId = inputProps?.id || this.inputId
 
     let { focused } = this.state
     let inputReadOnly = inputProps ? inputProps.readOnly : null

--- a/packages/react-widgets/src/util/widgetHelpers.js
+++ b/packages/react-widgets/src/util/widgetHelpers.js
@@ -23,3 +23,7 @@ export function isFirstFocusedRender(component) {
       (component._firstFocus = true))
   )
 }
+
+export function hasValidCustomInputId(inputProps) {
+  return inputProps && typeof inputProps.id === 'string'
+}

--- a/packages/react-widgets/src/util/widgetHelpers.js
+++ b/packages/react-widgets/src/util/widgetHelpers.js
@@ -24,6 +24,3 @@ export function isFirstFocusedRender(component) {
   )
 }
 
-export function hasValidCustomInputId(inputProps) {
-  return inputProps && typeof inputProps.id === 'string'
-}

--- a/packages/react-widgets/src/util/widgetHelpers.js
+++ b/packages/react-widgets/src/util/widgetHelpers.js
@@ -23,4 +23,3 @@ export function isFirstFocusedRender(component) {
       (component._firstFocus = true))
   )
 }
-

--- a/packages/react-widgets/test/Combobox-test.js
+++ b/packages/react-widgets/test/Combobox-test.js
@@ -418,4 +418,29 @@ describe('Combobox', function(){
     expect(inst.find('List li').at(2).is('.rw-state-focus')).to.equal(false)
     expect(inst.find('List li').at(3).is('.rw-state-focus')).to.equal(true)
   })
+
+  it('sets given custom id prop for ComboboxInput without suffix if valid', () => {
+    const componentWithCustomId = shallow(<ControlledCombobox
+        open={true}
+        inputProps={{id:'custom-dt-id'}}
+        filter={'contains'}
+        data={dataList}
+        value='smith'
+        minLength={2}
+        textField='label'
+        valueField='id'
+      />)
+    expect(componentWithCustomId.find('ComboboxInput').prop('id')).to.equal('custom-dt-id')
+
+    const componentWithoutCustomId = shallow(<ControlledCombobox
+      open={true}
+      filter={'contains'}
+      data={dataList}
+      value='smith'
+      minLength={2}
+      textField='label'
+      valueField='id'
+    />)
+    expect(componentWithoutCustomId.find('ComboboxInput').prop('id')).to.match(/rw_(\d+)_input/)
+  })
 })

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -69,9 +69,12 @@ describe('DateTimePicker', () => {
     inst.assertSingle(`[aria-owns='${dateId}']`)
   })
 
-  it('sets given custom id prop for DateTimePickerInput without suffix', () => {
-    const inst = shallow(<ControlledDateTimePicker id="custom-dt-id" open="date" time={false} />)
-    expect(inst.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
+  it('sets given custom id prop for DateTimePickerInput without suffix if valid', () => {
+    const componentWithValidId = shallow(<ControlledDateTimePicker inputProps={{id:'custom-dt-id'}} open="date" time={false} />)
+    expect(componentWithValidId.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
+
+    const componentWithInvalidId = shallow(<ControlledDateTimePicker inputProps={{id: false}} open="date" time={false} />)
+    expect(componentWithInvalidId.find('DateTimePickerInput').prop('id')).to.match(/rw_(\d+)_input/)
   })
 
   it('sets aria-owns relationship for TimePicker', () => {

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -69,7 +69,7 @@ describe('DateTimePicker', () => {
     inst.assertSingle(`[aria-owns='${dateId}']`)
   })
 
-  it('sets aria-owns relationship for DateTimePicker', () => {
+  it('sets given custom id prop for DateTimePickerInput without suffix', () => {
     const inst = shallow(<ControlledDateTimePicker id="custom-dt-id" open="date" time={false} />)
     expect(inst.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
   })

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -69,6 +69,13 @@ describe('DateTimePicker', () => {
     inst.assertSingle(`[aria-owns='${dateId}']`)
   })
 
+  it('sets aria-owns relationship for Calendar', () => {
+    const inst = shallow(<ControlledDateTimePicker id="custom-dt" open="date" time={false} />)
+    const dateId = inst.find(Calendar).props().id
+    expect(dateId).toEqual('custom-dt')
+    inst.assertSingle(`[aria-owns='${dateId}']`)
+  })
+
   it('sets aria-owns relationship for TimePicker', () => {
     const inst = shallow(<ControlledDateTimePicker open="time" date={false} time={true} />)
     const listId = inst.find(TimeList).props().id

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -69,14 +69,6 @@ describe('DateTimePicker', () => {
     inst.assertSingle(`[aria-owns='${dateId}']`)
   })
 
-  it('sets given custom id prop for DateTimePickerInput without suffix if valid', () => {
-    const componentWithValidId = shallow(<ControlledDateTimePicker inputProps={{id:'custom-dt-id'}} open="date" time={false} />)
-    expect(componentWithValidId.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
-
-    const componentWithInvalidId = shallow(<ControlledDateTimePicker inputProps={{id: false}} open="date" time={false} />)
-    expect(componentWithInvalidId.find('DateTimePickerInput').prop('id')).to.match(/rw_(\d+)_input/)
-  })
-
   it('sets aria-owns relationship for TimePicker', () => {
     const inst = shallow(<ControlledDateTimePicker open="time" date={false} time={true} />)
     const listId = inst.find(TimeList).props().id
@@ -260,6 +252,14 @@ describe('DateTimePicker', () => {
     wrapper.simulate('keyDown', { key: 'ArrowDown' })
 
     expect(options[options.length - 1].className).to.match(/\brw-state-focus\b/)
+  })
+
+  it('sets given custom id prop for DateTimePickerInput without suffix if valid', () => {
+    const componentWithCustomId = shallow(<ControlledDateTimePicker inputProps={{id:'custom-dt-id'}} open="date" time={false} />)
+    expect(componentWithCustomId.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
+
+    const componentWithoutCustomId = shallow(<ControlledDateTimePicker open="date" time={false} />)
+    expect(componentWithoutCustomId.find('DateTimePickerInput').prop('id')).to.match(/rw_(\d+)_input/)
   })
 
   describe('TimeList', () => {

--- a/packages/react-widgets/test/DateTimePicker-test.js
+++ b/packages/react-widgets/test/DateTimePicker-test.js
@@ -69,11 +69,9 @@ describe('DateTimePicker', () => {
     inst.assertSingle(`[aria-owns='${dateId}']`)
   })
 
-  it('sets aria-owns relationship for Calendar', () => {
-    const inst = shallow(<ControlledDateTimePicker id="custom-dt" open="date" time={false} />)
-    const dateId = inst.find(Calendar).props().id
-    expect(dateId).toEqual('custom-dt')
-    inst.assertSingle(`[aria-owns='${dateId}']`)
+  it('sets aria-owns relationship for DateTimePicker', () => {
+    const inst = shallow(<ControlledDateTimePicker id="custom-dt-id" open="date" time={false} />)
+    expect(inst.find('DateTimePickerInput').prop('id')).to.equal('custom-dt-id')
   })
 
   it('sets aria-owns relationship for TimePicker', () => {


### PR DESCRIPTION
[DateTimePicker - use the given input id prop as is, instead of suffixing with '_input](https://github.com/jquense/react-widgets/issues/1023)

