### PR TITLE
Allow users to provide a custom Popup component

### DIFF
--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -83,6 +83,7 @@ class DropdownList extends React.Component {
      */
     valueComponent: CustomPropTypes.elementType,
     itemComponent: CustomPropTypes.elementType,
+    popupComponent: CustomPropTypes.elementType,
     listComponent: CustomPropTypes.elementType,
     optionComponent: CustomPropTypes.elementType,
 
@@ -125,6 +126,7 @@ class DropdownList extends React.Component {
 
     inputProps: PropTypes.object,
     listProps: PropTypes.object,
+    popupProps: PropTypes.object,
 
     isRtl: PropTypes.bool,
     messages: PropTypes.shape({
@@ -144,6 +146,7 @@ class DropdownList extends React.Component {
     searchIcon: search,
     selectIcon: caretDown,
     listComponent: List,
+    popupComponent: Popup
   }
 
   constructor(...args) {
@@ -370,6 +373,7 @@ class DropdownList extends React.Component {
   attachInputRef = ref => (this.inputRef = ref)
   attachFilterRef = ref => (this.filterRef = ref)
   attachListRef = ref => (this.listRef = ref)
+  attachPopupRef = ref => (this.popupRef = ref);
 
   renderList() {
     let {
@@ -450,11 +454,32 @@ class DropdownList extends React.Component {
     )
   }
 
+  renderPopup() {
+    let {
+      popupTransition,
+      dropUp,
+      open,
+      popupProps={}
+    } = this.props
+
+    let Popup = this.props.popupComponent;
+
+    return (<Popup
+    {...popupProps}
+    ref={this.attachPopupRef}
+    open={open}
+    dropUp={dropUp}
+    transition={popupTransition}
+    onEntered={() => this.focus()}
+    onEntering={() => this.listRef.forceUpdate()}>
+    {this.renderList()}
+  </Popup>)
+  }
+
   render() {
     let {
       className,
       tabIndex,
-      popupTransition,
       textField,
       data,
       busy,
@@ -477,7 +502,7 @@ class DropdownList extends React.Component {
     let readOnly = this.props.readOnly === true
     let valueItem = accessors.findOrSelf(data, value)
 
-    let shouldRenderPopup = isFirstFocusedRender(this)
+    const shouldRenderPopup = isFirstFocusedRender(this)
 
     let elementProps = Object.assign(Props.pickElementProps(this), {
       name: undefined,
@@ -535,17 +560,9 @@ class DropdownList extends React.Component {
             label={messages.openDropdown(this.props)}
           />
         </WidgetPicker>
-        {shouldRenderPopup && (
-          <Popup
-            open={open}
-            dropUp={dropUp}
-            transition={popupTransition}
-            onEntered={() => this.focus()}
-            onEntering={() => this.listRef.forceUpdate()}
-          >
-            {this.renderList(messages)}
-          </Popup>
-        )}
+        {shouldRenderPopup &&
+          this.renderPopup()
+        }
       </Widget>
     )
   }

--- a/packages/react-widgets/src/Multiselect.js
+++ b/packages/react-widgets/src/Multiselect.js
@@ -81,6 +81,7 @@ let propTypes = {
   tagComponent: CustomPropTypes.elementType,
   itemComponent: CustomPropTypes.elementType,
   listComponent: CustomPropTypes.elementType,
+  popupComponent: CustomPropTypes.elementType,
 
   groupComponent: CustomPropTypes.elementType,
   groupBy: CustomPropTypes.accessor,
@@ -113,6 +114,7 @@ let propTypes = {
   containerClassName: PropTypes.string,
   inputProps: PropTypes.object,
   listProps: PropTypes.object,
+  popupProps: PropTypes.object,
 
   autoFocus: PropTypes.bool,
   placeholder: PropTypes.string,
@@ -170,6 +172,7 @@ class Multiselect extends React.Component {
     searchTerm: '',
     selectIcon: caretDown,
     listComponent: List,
+    popupComponent: Popup,
     showPlaceholderWithValues: false,
   }
 
@@ -488,6 +491,43 @@ class Multiselect extends React.Component {
     )
   }
 
+  renderPopup() {
+    let {
+      dropUp,
+      open,
+      searchTerm,
+      popupTransition,
+      popupProps,
+      popupComponent:Popup
+    } = this.props
+
+    let { focusedItem, messages } = this.state
+    let allowCreate = this.allowCreate();
+
+    return <Popup
+        {...popupProps}
+        dropUp={dropUp}
+        open={open}
+        transition={popupTransition}
+        onEntering={() => this.listRef.forceUpdate()}
+      >
+      <div>
+        {this.renderList()}
+
+        {allowCreate && (
+            <AddToListOption
+                id={this.createId}
+                searchTerm={searchTerm}
+                onSelect={this.handleCreate}
+                focused={!focusedItem || focusedItem === CREATE_OPTION}
+            >
+              {messages.createOption(this.props)}
+            </AddToListOption>
+        )}
+      </div>
+    </Popup>
+  }
+
   renderNotificationArea() {
     let { focused, dataItems, accessors, messages } = this.state
 
@@ -540,14 +580,12 @@ class Multiselect extends React.Component {
       busy,
       dropUp,
       open,
-      searchTerm,
       selectIcon,
       busySpinner,
       containerClassName,
-      popupTransition,
     } = this.props
 
-    let { focused, focusedItem, dataItems, messages } = this.state
+    let { focused, dataItems, messages } = this.state
 
     let elementProps = Props.pickElementProps(this)
 
@@ -598,29 +636,9 @@ class Multiselect extends React.Component {
           />
         </WidgetPicker>
 
-        {shouldRenderPopup && (
-          <Popup
-            dropUp={dropUp}
-            open={open}
-            transition={popupTransition}
-            onEntering={() => this.listRef.forceUpdate()}
-          >
-            <div>
-              {this.renderList()}
-
-              {allowCreate && (
-                <AddToListOption
-                  id={this.createId}
-                  searchTerm={searchTerm}
-                  onSelect={this.handleCreate}
-                  focused={!focusedItem || focusedItem === CREATE_OPTION}
-                >
-                  {messages.createOption(this.props)}
-                </AddToListOption>
-              )}
-            </div>
-          </Popup>
-        )}
+        {shouldRenderPopup &&
+          this.renderPopup()
+        }
       </Widget>
     )
   }

--- a/packages/react-widgets/test/DropdownList-test.js
+++ b/packages/react-widgets/test/DropdownList-test.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 
 import DropdownList from '../src/DropdownList'
+import SlideDownTransition from '../src/SlideDownTransition'
+import Popup from '../src/Popup'
 
 let ControlledDropdownList = DropdownList.ControlledComponent
 
@@ -358,5 +360,54 @@ describe('DROPDOWNS', function() {
       expect(inst.state('focusedItem')).to.equal(data[0])
       done()
     }, 10)
+  })
+
+  it('should render with a custom PopupComponent if one is provided', () => {
+    class CustomPopupComponent extends React.PureComponent {
+      render() {
+        return <div id="custom-popup-component" />
+      }
+    }
+
+    let inst = mount(
+        <ControlledDropdownList
+            open
+            dropUp
+            popupTransition={SlideDownTransition}
+            popupComponent={CustomPopupComponent}
+            popupProps={{
+              customProp: 'custom-prop'
+            }} />
+    );
+
+
+    const props = inst.find(CustomPopupComponent).props();
+
+    expect(props.open).to.equal(true);
+    expect(props.dropUp).to.equal(true);
+    expect(props.customProp).to.equal('custom-prop');
+    expect(props.transition).to.equal(SlideDownTransition);
+
+    const focus = sinon.stub(inst.instance(), 'focus');
+    expect(focus.notCalled).to.equal(true);
+    props.onEntered()
+    expect(focus.calledOnce).to.equal(true);
+
+    const forceUpdate = sinon.stub();
+
+    inst.instance().listRef = {
+      forceUpdate
+    }
+    expect(forceUpdate.notCalled).to.equal(true);
+    props.onEntering();
+    expect(forceUpdate.calledOnce).to.equal(true);
+  })
+
+  it('defaults to using a Popup component', () => {
+    let inst = mount(
+        <ControlledDropdownList open/>
+    );
+
+    expect(inst.find(Popup).exists()).to.equal(true);
   })
 })

--- a/packages/react-widgets/test/Multiselect-test.js
+++ b/packages/react-widgets/test/Multiselect-test.js
@@ -4,6 +4,8 @@ import { mount, shallow } from 'enzyme'
 import Multiselect from '../src/Multiselect'
 import MultiselectTag from '../src/MultiselectTag'
 import MultiselectTagList from '../src/MultiselectTagList'
+import SlideDownTransition from "../src/SlideDownTransition";
+import Popup from "../src/Popup";
 
 describe('Multiselect', function() {
   const ControlledMultiselect = Multiselect.ControlledComponent
@@ -587,5 +589,49 @@ describe('Multiselect', function() {
 
     inst.simulate('keyDown', { key: 'Home' })
     listItems.first().is('.rw-state-focus')
+  })
+
+  it('should render with a custom PopupComponent if one is provided', () => {
+    class CustomPopupComponent extends React.PureComponent {
+      render() {
+        return <div id="custom-popup-component" />
+      }
+    }
+
+    let inst = mount(
+        <ControlledMultiselect
+            open
+            dropUp
+            popupTransition={SlideDownTransition}
+            popupComponent={CustomPopupComponent}
+            popupProps={{
+              customProp: 'custom-prop'
+            }} />
+    );
+
+    const forceUpdate = sinon.stub();
+
+    inst.instance().listRef = {
+      forceUpdate
+    }
+
+    const props = inst.find(CustomPopupComponent).props();
+
+    expect(props.open).to.equal(true);
+    expect(props.dropUp).to.equal(true);
+    expect(props.customProp).to.equal('custom-prop');
+    expect(props.transition).to.equal(SlideDownTransition);
+
+    expect(forceUpdate.notCalled).to.equal(true);
+    props.onEntering();
+    expect(forceUpdate.calledOnce).to.equal(true);
+  })
+
+  it('defaults to using a Popup component', () => {
+    let inst = mount(
+        <ControlledMultiselect open/>
+    );
+
+    expect(inst.find(Popup).exists()).to.equal(true);
   })
 })


### PR DESCRIPTION
Allowing a custom Popup component provides flexibility for when you may need to Portal the List away from it's container. Overriding List in that scenario would cause the Filter and Create options to be separate from the List itself which caused display issues.