### PR TITLE
fix: add guard on "key" in Widget keydown handler

### DIFF
--- a/packages/react-widgets/src/Widget.tsx
+++ b/packages/react-widgets/src/Widget.tsx
@@ -18,7 +18,7 @@ function useKeyboardNavigationCheck() {
       key == ' ' ||
       key === 'Tab' ||
       key == 'Enter' ||
-      key.indexOf('Arrow') !== -1
+      (key && key.indexOf('Arrow') !== -1)
     ) {
       setIsNavigatingViaKeyboard(true)
     }


### PR DESCRIPTION
`key` can be undefined in certain circumstances. The one I saw was with Chrome autofill drop-downs. If you "arrow down" into a Chrome autofill box and then tab out of it, `key` is undefined, presumably because it was attached to the dropdown which no longer exists.