### PR TITLE
avoid dependency on date-arithmetic types

### DIFF
--- a/packages/react-widgets/src/CalendarView.tsx
+++ b/packages/react-widgets/src/CalendarView.tsx
@@ -1,8 +1,18 @@
 import cn from 'classnames'
-import { DateUnit } from 'date-arithmetic'
 import React, { ReactNode, useEffect, useRef } from 'react'
 import dates from './dates'
 import useFocusManager from './useFocusManager'
+
+export type DateUnit =
+| 'second'
+| 'minutes'
+| 'hours'
+| 'day'
+| 'week'
+| 'month'
+| 'year'
+| 'decade'
+| 'century'
 
 function clamp(date: Date, min: Date, max: Date) {
   return dates.max(dates.min(date, max), min)


### PR DESCRIPTION
I tried to update `react-widgets` to `5.0.0-beta.21` in [signum framework](https://github.com/signumsoftware/framework) to avoid the React 17 warnings but I got the following error: 

```
D:\Signum\southwind\Framework\Signum.React\node_modules\react-widgets\lib\CalendarView.d.ts(1,26): error TS2306: Build:File 'D:/Signum/southwind/Framework/Signum.React/node_modules/@types/date-arithmetic/index.d.ts' is not a module.
```

The problem seems to be that in https://github.com/jquense/react-widgets/blob/5d4985c6dac0df34b86c7d8ad311ff97066977ab/packages/react-widgets/src/CalendarView.tsx#L2 there is a reference to an external library: 


Thas is defined in  https://github.com/jquense/react-widgets/blob/5d4985c6dac0df34b86c7d8ad311ff97066977ab/packages/react-widgets/globals.d.ts#L35 

I think this library is meant to be an implementation detail that's why you used `declare module` instead of adding a packages.json dependency, but because you are exporting the type, then there is an error in the compiled d.ts files. 

My solution is just to copy-paste the definition inside `CalendarView.tsx` and rely in Typescript structural type system. 

Alternatively we could add a dependency to `https://www.npmjs.com/package/@types/date-arithmetic` 