### PR TITLE
Fix inputProps not being applied on DropdownList

### DIFF
--- a/packages/react-widgets/src/DropdownList.js
+++ b/packages/react-widgets/src/DropdownList.js
@@ -515,7 +515,7 @@ class DropdownList extends React.Component {
           className={cn(containerClassName, 'rw-widget-input')}
         >
           <DropdownListInput
-            {...inputProps}
+            inputProps={inputProps}
             value={valueItem}
             textField={textField}
             name={this.props.name}

--- a/packages/react-widgets/src/DropdownListInput.js
+++ b/packages/react-widgets/src/DropdownListInput.js
@@ -16,6 +16,7 @@ class DropdownListInput extends React.Component {
     valueComponent: CustomPropTypes.elementType,
     onAutofill: PropTypes.func.isRequired,
     onAutofillChange: PropTypes.func.isRequired,
+    inputProps: PropTypes.object,
   }
   state = {
     autofilling: false,
@@ -45,6 +46,7 @@ class DropdownListInput extends React.Component {
       textField,
       autoComplete,
       valueComponent: Component,
+      inputProps,
     } = this.props
     const { autofilling } = this.state
     let child = null
@@ -67,6 +69,7 @@ class DropdownListInput extends React.Component {
             name={name}
             value={val == null ? '' : val}
             autoComplete={autoComplete}
+            {...inputProps}
             onChange={this.handleAutofill}
             onAnimationStart={this.handleAutofillDetect}
             className={cn(


### PR DESCRIPTION
Fixes #963

The `inputProps` were not being applied to the input in the `DropdownListInput` component. 