### PR TITLE
fix: user deletes when there are no tags in Multiselect

### DIFF
--- a/packages/react-widgets/src/FocusListContext.ts
+++ b/packages/react-widgets/src/FocusListContext.ts
@@ -26,6 +26,7 @@ export interface FocusProps {
 }
 
 export interface FocusList<TDataItem = unknown> {
+  size(): number;
   focus: (el: HTMLElement | null | undefined) => void
   first: () => HTMLElement | undefined
   last: () => HTMLElement | undefined
@@ -103,6 +104,10 @@ export const useFocusList = <TDataItem>({
 
   const list: any = useMemo(() => {
     return {
+      size() {
+        const [items] = get();
+        return items.length;
+      },
       get,
       toDataItem: (el: HTMLElement) => map.get(el),
 

--- a/packages/react-widgets/src/Multiselect.tsx
+++ b/packages/react-widgets/src/Multiselect.tsx
@@ -383,7 +383,7 @@ const Multiselect: Multiselect = React.forwardRef(function Multiselect<
    */
 
   const handleDelete = (dataItem: TDataItem, event: React.SyntheticEvent) => {
-    if (isDisabled || readOnly) return
+    if (isDisabled || readOnly || tagList.size() === 0) return
     focus()
     change(dataItem, event, REMOVE)
   }


### PR DESCRIPTION
If a user presses delete when there are no tags in the list in a Multiselect component, it will trigger a change, which may trigger unexpected handlers. Typically, changes to a component where no state changes (ie. deleting nothing) results in no changes, therefore I propose adding a check when a user tries to delete in order to guard from this case.

I also provide a simple utility function for tag list size -- the main purpose of this is to make it more clear to code readers as to why that check exists without having to understand the internals of `FocusList` -- as opposed to a direct usage like `tagList.get()[0].length`