### PR TITLE
Fix warning in number-picker.scss

### DIFF
--- a/packages/react-widgets/src/scss/number-picker.scss
+++ b/packages/react-widgets/src/scss/number-picker.scss
@@ -1,8 +1,9 @@
+@use 'sass:math';
 @use './variables.scss' as *;
 
 @mixin NumberPicker() {
   .rw-number-picker {
-    $half-width: $input-height / 2;
+    $half-width: math.div($input-height, 2);
   }
 
   .rw-number-picker-spinners {


### PR DESCRIPTION
Hello,

I have change number-picker.scss to fix the following warning with Dart sass :
`DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($input-height, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
5 │     $half-width: $input-height / 2;
  │                  ^^^^^^^^^^^^^^^^^
  ╵
    node_modules/react-widgets/scss/number-picker.scss 5:18  NumberPicker()
    node_modules/react-widgets/scss/components.scss 98:5     @forward
    node_modules/react-widgets/scss/styles.scss 3:1          root stylesheet
`