### PR TITLE
remove warning from dependencies

### DIFF
--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -69,8 +69,7 @@
     "prop-types-extra": "^1.1.1",
     "react-transition-group": "^4.4.1",
     "tiny-warning": "^1.0.3",
-    "uncontrollable": "^7.2.1",
-    "warning": "^4.0.3"
+    "uncontrollable": "^7.2.1"
   },
   "devDependencies": {
     "@4c/build": "^2.2.8",


### PR DESCRIPTION
During the transition from 'warning' to 'tiny-warning' the warning package was not removed

https://github.com/jquense/react-widgets/commit/680134208e49996005de31a370a58d5204768a39