### PR TITLE
Add defaultValue type to Timeinput compoenent

### DIFF
--- a/packages/react-widgets/src/TimeInput.tsx
+++ b/packages/react-widgets/src/TimeInput.tsx
@@ -113,7 +113,7 @@ const isComplete = (value: string, part: TimePart, use12HourClock: boolean) =>
   testPart(value, part, use12HourClock, TEST_COMPLETE)
 
 export interface TimeInputProps
-  extends Omit<WidgetProps, 'value' | 'onChange'> {
+  extends Omit<WidgetProps, 'value' | 'onChange' | 'defaultValue'> {
   value?: Date | null
   defaultValue?: Date | null
   onChange?: (date: Date | null, ctx?: any) => void

--- a/packages/react-widgets/src/TimeInput.tsx
+++ b/packages/react-widgets/src/TimeInput.tsx
@@ -138,6 +138,11 @@ const propTypes = {
   value: PropTypes.instanceOf(Date),
 
   /**
+   * @example ['valuePicker', [ ['new Date()'] ]]
+   */
+   defaultValue: PropTypes.instanceOf(Date),
+
+  /**
    * @example ['onChangePicker', [ ['new Date()'] ]]
    */
   onChange: PropTypes.func,
@@ -475,6 +480,7 @@ function TimeInput(uncontrolledProps: TimeInputProps) {
   return (
     <Widget
       {...props}
+      defaultValue={undefined}
       role="group"
       ref={ref}
       {...focusEvents}

--- a/packages/react-widgets/src/TimeInput.tsx
+++ b/packages/react-widgets/src/TimeInput.tsx
@@ -115,6 +115,7 @@ const isComplete = (value: string, part: TimePart, use12HourClock: boolean) =>
 export interface TimeInputProps
   extends Omit<WidgetProps, 'value' | 'onChange'> {
   value?: Date | null
+  defaultValue?: Date | null
   onChange?: (date: Date | null, ctx?: any) => void
   datePart?: Date
   use12HourClock?: boolean


### PR DESCRIPTION
Typescript was throwing a type error when trying to provide a defaultValue to the TimeInput component. Have defined the type mirroring the approach taken for the DatePicker component.