### PR TITLE
fix: add back btn input reset class and remove styles

### DIFF
--- a/packages/tailwind/src/widget.ts
+++ b/packages/tailwind/src/widget.ts
@@ -286,18 +286,9 @@ export const plugin = ({
     }
 
     .rw-input {
-      @apply rw-input-base;
+      @apply rw-btn-input-reset rw-input-base;
 
       padding: 0 ${theme('rwInput.paddingX')};
-      margin: 0;
-      border: none;
-      color: inherit;
-      box-shadow: none;
-      background: none;
-      font: inherit;
-      line-height: inherit;
-      touch-action: manipulation;
-      outline: 0;
 
       &[type='text']::-ms-clear {
         display: none;


### PR DESCRIPTION
Reverts some of the changes from https://github.com/jquense/react-widgets/commit/bd0631a95c1303403b6341e090516e3068661014