### PR TITLE
RW input icon button hidden fix

### DIFF
--- a/packages/react-widgets/src/scss/widget.scss
+++ b/packages/react-widgets/src/scss/widget.scss
@@ -184,6 +184,7 @@ fieldset[disabled] .rw-widget {
   background-color: $input-bg;
   box-shadow: $input-box-shadow;
   background-clip: $widget-background-clip;
+  width: inherit;
 
   // Listbox is also the rw-widget
   &.rw-state-disabled,


### PR DESCRIPTION
Fixes #1119 

Adds ```width: inherit;``` for ```.rw-widget-input``` class which stops the input icon button on Datepicker, NumberPicker and Combobox components from overflowing/getting hidden when width of component is below than some threshold (approx. 250px). Thanks!