### PR TITLE
Blur Input Field Automatically After Date Selection in DatePicker

### DIFF
--- a/packages/react-widgets/src/DatePicker.tsx
+++ b/packages/react-widgets/src/DatePicker.tsx
@@ -468,7 +468,7 @@ const DatePicker = React.forwardRef(
 
       notify(onSelect, [dateTime, dateStr])
       handleChange(dateTime, dateStr, true)
-      ref.current?.focus()
+      ref.current?.blur()
     })
 
     const handleTimeChange = useEventCallback((date) => {


### PR DESCRIPTION
This change should ensure that the input field in the `DatePicker` loses focus automatically after a date is selected. On devices with on-screen keyboards, it can be annoying when the input field remains focused, causing the keyboard to open unnecessarily after the user has already selected a date.

Note: **This change has not been tested at all and should be thoroughly verified before merging.**